### PR TITLE
fix(server): serve SPA index.html on deep-link/hard-reload instead of 404

### DIFF
--- a/lelab/server.py
+++ b/lelab/server.py
@@ -31,6 +31,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
+from starlette.datastructures import Headers
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.responses import Response
+from starlette.types import Scope
 
 from . import datasets as dataset_browser
 
@@ -1112,9 +1116,55 @@ async def shutdown_event():
     logger.info("✅ Cleanup completed")
 
 
+def _accepts_html(accept: str) -> bool:
+    """Whether an Accept header explicitly wants text/html (quality > 0).
+
+    Browser navigations list `text/html` with a positive quality value, so
+    they get the SPA shell. A `text/html;q=0` entry is an explicit refusal and
+    must not count — a plain substring check would wrongly treat it as a yes.
+    `*/*` (curl, XHR, API clients) is deliberately not treated as wanting HTML.
+    """
+    for part in accept.split(","):
+        media_type, _, params = part.strip().partition(";")
+        if media_type.strip().lower() != "text/html":
+            continue
+        quality = 1.0
+        for param in params.split(";"):
+            key, _, value = param.partition("=")
+            if key.strip().lower() == "q":
+                try:
+                    quality = float(value)
+                except ValueError:
+                    quality = 0.0
+        return quality > 0
+    return False
+
+
+class SPAStaticFiles(StaticFiles):
+    """StaticFiles that serves index.html for unknown client-side routes.
+
+    The frontend is a single-page app: routes like /recording and /calibration
+    exist only in the browser's router, not as files on disk. A hard reload or
+    deep link to one of those URLs asks the server for a file that isn't there;
+    plain StaticFiles answers 404 ({"detail":"Not Found"}), so the page breaks.
+
+    Here we fall back to index.html on 404 so the SPA boots and its router
+    renders the route. Only requests that accept HTML (i.e. browser navigations)
+    get the fallback — API typos, XHR, and curl still receive a JSON 404.
+    """
+
+    async def get_response(self, path: str, scope: Scope) -> Response:
+        try:
+            return await super().get_response(path, scope)
+        except StarletteHTTPException as exc:
+            if exc.status_code == 404 and _accepts_html(Headers(scope=scope).get("accept", "")):
+                return await super().get_response("index.html", scope)
+            raise
+
+
 # Serve the built frontend at /. Must be mounted last so API routes win.
 if FRONTEND_DIST.exists():
-    app.mount("/", StaticFiles(directory=FRONTEND_DIST, html=True), name="frontend")
+    app.mount("/", SPAStaticFiles(directory=FRONTEND_DIST, html=True), name="frontend")
 else:
     logger.warning(
         f"frontend/dist not found at {FRONTEND_DIST}; run `npm run build` in frontend/ or use `lelab --dev`."

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,7 +17,11 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from fastapi.testclient import TestClient
+
+# A browser sends an Accept header that prefers HTML on navigations/hard-reloads.
+BROWSER_ACCEPT = {"accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}
 
 REQUIRED_PATHS = {
     "/health",
@@ -63,6 +67,51 @@ def test_health_endpoint_returns_dict(client: TestClient) -> None:
 def test_unknown_route_returns_404(client: TestClient) -> None:
     response = client.get("/this-does-not-exist")
     assert response.status_code == 404
+
+
+def _spa_mounted(client: TestClient) -> bool:
+    return any(getattr(route, "name", None) == "frontend" for route in client.app.routes)
+
+
+def test_spa_deep_link_serves_index_html(client: TestClient) -> None:
+    """A browser hard-reload of a client-side route returns the SPA shell, not a 404."""
+    if not _spa_mounted(client):
+        pytest.skip("frontend/dist not built; SPA not mounted")
+    response = client.get("/recording", headers=BROWSER_ACCEPT)
+    assert response.status_code == 200
+    assert response.text.lstrip().lower().startswith("<!doctype html")
+
+
+def test_spa_fallback_does_not_mask_api_404(client: TestClient) -> None:
+    """Non-HTML clients (XHR, curl, API typos) still get a real 404, not the SPA shell."""
+    response = client.get("/recording", headers={"accept": "application/json"})
+    assert response.status_code == 404
+
+
+def test_spa_fallback_respects_explicit_html_refusal(client: TestClient) -> None:
+    """`text/html;q=0` is an explicit refusal — it must not get the SPA shell."""
+    response = client.get("/recording", headers={"accept": "application/json,text/html;q=0"})
+    assert response.status_code == 404
+
+
+@pytest.mark.parametrize(
+    ("accept", "expected"),
+    [
+        ("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", True),
+        ("text/html", True),
+        ("text/html;q=0.5", True),
+        ("application/json", False),
+        ("*/*", False),
+        ("", False),
+        ("text/html;q=0", False),
+        ("application/json,text/html;q=0", False),
+        ("text/html;q=bogus", False),
+    ],
+)
+def test_accepts_html(accept: str, expected: bool) -> None:
+    from lelab.server import _accepts_html
+
+    assert _accepts_html(accept) is expected
 
 
 def test_connection_manager_tracks_connect_and_disconnect() -> None:


### PR DESCRIPTION
## What does this PR do?

Hard-reloading or deep-linking any client-side route (e.g. `/recording`,
`/calibration`, `/teleoperation`) currently returns
`404 {"detail":"Not Found"}` and a blank page instead of the app.

The frontend is a single-page app: those routes live only in the browser's
router, not as files on disk. The `/` `StaticFiles` mount has no SPA fallback,
so any request for a path that isn't a real file 404s. The first load of `/`
and in-app navigation work (the browser handles routing client-side), so the
gap only surfaces on a hard reload or when a deep link is opened directly.

## How it's fixed

Add a small `SPAStaticFiles(StaticFiles)` subclass that, on a 404, falls back
to serving `index.html` so the SPA boots and its router renders the route.

The fallback only applies to **browser navigations** ie requests whose `Accept`
header actually wants `text/html`. API typos, XHR, and `curl` (which send
`application/json` or `*/*`) still receive a real JSON 404, so genuine API
errors are not masked. A dedicated `_accepts_html()` helper parses the header
and honors quality values, so an explicit `text/html;q=0` refusal is treated
as "no", not a substring match.

The mount stays last, after all API routes, so API endpoints continue to win.

## Before / After

| Request | Before | After |
| --- | --- | --- |
| Browser reload of `/recording` | `404` blank page | `200` app loads |
| `curl`/XHR for an unknown path | `404` JSON | `404` JSON (unchanged) |
| `GET /health`, `GET /` | `200` | `200` (unchanged) |

## Testing

- Added regression tests in `tests/test_server.py`: the HTML deep-link
  fallback, preservation of the JSON 404 for non-HTML clients, the
  `text/html;q=0` refusal path, and a parametrized table for `_accepts_html`.
- `pytest` and `pre-commit` (ruff, mypy, bandit, …) pass locally.
- Verified manually: ran `lelab`, hard-reloaded `/recording` and
  `/calibration` in the browser — pages load instead of the 404 blank screen.
