### PR TITLE
feat: per-camera FOURCC & backend in camera config GUI

### DIFF
--- a/frontend/src/components/recording/CameraConfiguration.tsx
+++ b/frontend/src/components/recording/CameraConfiguration.tsx
@@ -10,10 +10,32 @@ import {
 } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { NumberInput } from "@/components/ui/number-input";
-import { Camera, Plus, X, VideoOff, RefreshCw } from "lucide-react";
+import { Camera, Plus, X, VideoOff, RefreshCw, ChevronRight } from "lucide-react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { useToast } from "@/hooks/use-toast";
 import { useAvailableCameras } from "@/hooks/useAvailableCameras";
 import { useCameraStream } from "@/hooks/useCameraStream";
+
+// Sentinels distinguish "leave unset" (auto-detect / platform default) from an
+// explicit choice. Radix Select disallows an empty-string value, so we map these
+// to `undefined` on the CameraConfig.
+const FOURCC_AUTO = "__auto__";
+const BACKEND_DEFAULT = "__default__";
+const FOURCC_OPTIONS = ["MJPG", "YUYV", "I420", "NV12", "H264", "MP4V"];
+// Mirrors lerobot's Cv2Backends enum names.
+const BACKEND_OPTIONS = [
+  "ANY",
+  "V4L2",
+  "DSHOW",
+  "PVAPI",
+  "ANDROID",
+  "AVFOUNDATION",
+  "MSMF",
+];
 
 export interface CameraConfig {
   id: string;
@@ -351,48 +373,119 @@ const CameraPreview: React.FC<CameraPreviewProps> = ({
           </Button>
         </div>
 
-        <div className="grid grid-cols-1 gap-2 text-xs text-gray-400">
-          <div className="flex items-center gap-2">
-            <span className="w-16">Resolution:</span>
-            <div className="flex items-center gap-1">
-              <NumberInput
-                value={camera.width}
-                onChange={(v) => {
-                  if (v !== undefined) onUpdate({ width: v });
-                }}
-                className="bg-gray-800 border-gray-700 text-white text-xs h-6 px-2 w-16"
-                min="320"
-                max="1920"
-              />
-              <span className="flex items-center">×</span>
-              <NumberInput
-                value={camera.height}
-                onChange={(v) => {
-                  if (v !== undefined) onUpdate({ height: v });
-                }}
-                className="bg-gray-800 border-gray-700 text-white text-xs h-6 px-2 w-16"
-                min="240"
-                max="1080"
-              />
+        <Collapsible>
+          <CollapsibleTrigger className="group flex items-center gap-1.5 text-xs font-medium text-gray-300 hover:text-white transition-colors">
+            <ChevronRight className="w-3.5 h-3.5 transition-transform group-data-[state=open]:rotate-90" />
+            Configuration
+          </CollapsibleTrigger>
+          <CollapsibleContent className="pt-2 space-y-2">
+            <div className="grid grid-cols-1 gap-2 text-xs text-gray-400">
+              <div className="flex items-center gap-2">
+                <span className="w-16">Resolution:</span>
+                <div className="flex items-center gap-1">
+                  <NumberInput
+                    value={camera.width}
+                    onChange={(v) => {
+                      if (v !== undefined) onUpdate({ width: v });
+                    }}
+                    className="bg-gray-800 border-gray-700 text-white text-xs h-6 px-2 w-16"
+                    min="320"
+                    max="1920"
+                  />
+                  <span className="flex items-center">×</span>
+                  <NumberInput
+                    value={camera.height}
+                    onChange={(v) => {
+                      if (v !== undefined) onUpdate({ height: v });
+                    }}
+                    className="bg-gray-800 border-gray-700 text-white text-xs h-6 px-2 w-16"
+                    min="240"
+                    max="1080"
+                  />
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="w-16">FPS:</span>
+                <NumberInput
+                  value={camera.fps ?? 30}
+                  onChange={(v) => {
+                    if (v !== undefined) onUpdate({ fps: v });
+                  }}
+                  className="bg-gray-800 border-gray-700 text-white text-xs h-6 px-2 w-16"
+                  min="10"
+                  max="60"
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="w-16">FOURCC:</span>
+                <Select
+                  value={camera.fourcc ?? FOURCC_AUTO}
+                  onValueChange={(v) =>
+                    onUpdate({ fourcc: v === FOURCC_AUTO ? undefined : v })
+                  }
+                >
+                  <SelectTrigger className="bg-gray-800 border-gray-700 text-white text-xs h-6 px-2 w-28">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent className="bg-gray-800 border-gray-700">
+                    <SelectItem
+                      value={FOURCC_AUTO}
+                      className="text-white hover:bg-gray-700 text-xs"
+                    >
+                      Auto
+                    </SelectItem>
+                    {FOURCC_OPTIONS.map((code) => (
+                      <SelectItem
+                        key={code}
+                        value={code}
+                        className="text-white hover:bg-gray-700 text-xs"
+                      >
+                        {code}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="w-16">Backend:</span>
+                <Select
+                  value={camera.backend ?? BACKEND_DEFAULT}
+                  onValueChange={(v) =>
+                    onUpdate({ backend: v === BACKEND_DEFAULT ? undefined : v })
+                  }
+                >
+                  <SelectTrigger className="bg-gray-800 border-gray-700 text-white text-xs h-6 px-2 w-28">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent className="bg-gray-800 border-gray-700">
+                    <SelectItem
+                      value={BACKEND_DEFAULT}
+                      className="text-white hover:bg-gray-700 text-xs"
+                    >
+                      Default
+                    </SelectItem>
+                    {BACKEND_OPTIONS.map((name) => (
+                      <SelectItem
+                        key={name}
+                        value={name}
+                        className="text-white hover:bg-gray-700 text-xs"
+                      >
+                        {name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <p className="text-[10px] text-gray-500 leading-tight">
+                Overriding the backend can reorder camera indices on macOS.
+              </p>
             </div>
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="w-16">FPS:</span>
-            <NumberInput
-              value={camera.fps ?? 30}
-              onChange={(v) => {
-                if (v !== undefined) onUpdate({ fps: v });
-              }}
-              className="bg-gray-800 border-gray-700 text-white text-xs h-6 px-2 w-16"
-              min="10"
-              max="60"
-            />
-          </div>
-        </div>
-
-        <div className="text-xs text-gray-500">
-          Type: {camera.type} | Device: {camera.device_id?.substring(0, 10)}...
-        </div>
+            <div className="text-xs text-gray-500">
+              Type: {camera.type} | Device:{" "}
+              {camera.device_id?.substring(0, 10)}...
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
       </div>
     </div>
   );

--- a/frontend/src/components/recording/CameraConfiguration.tsx
+++ b/frontend/src/components/recording/CameraConfiguration.tsx
@@ -24,6 +24,8 @@ export interface CameraConfig {
   width: number;
   height: number;
   fps?: number;
+  fourcc?: string; // 4-char OpenCV pixel format (e.g. "MJPG"); undefined = auto-detect
+  backend?: string; // Cv2Backends name (e.g. "AVFOUNDATION"); undefined = platform default
 }
 
 interface CameraConfigurationProps {

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -178,6 +178,8 @@ const Landing = () => {
           width: cam.width,
           height: cam.height,
           fps: cam.fps,
+          ...(cam.fourcc ? { fourcc: cam.fourcc } : {}),
+          ...(cam.backend ? { backend: cam.backend } : {}),
         };
         return acc;
       },
@@ -189,6 +191,8 @@ const Landing = () => {
           width: number;
           height: number;
           fps?: number;
+          fourcc?: string;
+          backend?: string;
         }
       >,
     );

--- a/lelab/record.py
+++ b/lelab/record.py
@@ -84,52 +84,75 @@ class DatasetInfoRequest(BaseModel):
     dataset_repo_id: str
 
 
-def create_record_config(request: RecordingRequest) -> RecordConfig:
-    """Create a RecordConfig from the recording request"""
+def _platform_backend():
+    """Pin the OpenCV backend per-platform so the index→camera mapping matches
+    what the /available-cameras thumbnails were captured with. cv2.CAP_ANY can
+    pick different backends across calls on macOS, silently reordering cameras
+    between the modal preview and the recording."""
     import platform
 
     from lerobot.cameras.configs import Cv2Backends
-    from lerobot.cameras.opencv import OpenCVCameraConfig
 
-    # Pin the backend so the index→camera mapping matches what the
-    # /available-cameras thumbnails were captured with. cv2.CAP_ANY can
-    # pick different backends across calls on macOS, which silently
-    # reorders the cameras between the modal's preview and the recording.
-    if platform.system() == "Darwin":
-        opencv_backend = Cv2Backends.AVFOUNDATION
-    elif platform.system() == "Linux":
-        opencv_backend = Cv2Backends.V4L2
-    elif platform.system() == "Windows":
+    system = platform.system()
+    if system == "Darwin":
+        return Cv2Backends.AVFOUNDATION
+    if system == "Linux":
+        return Cv2Backends.V4L2
+    if system == "Windows":
         # DirectShow, matching the order /available-cameras enumerates (via
         # pygrabber) so a camera_index always opens the previewed device.
-        opencv_backend = Cv2Backends.DSHOW
-    else:
-        opencv_backend = Cv2Backends.ANY
+        return Cv2Backends.DSHOW
+    return Cv2Backends.ANY
 
+
+def _build_camera_configs(cameras: dict, default_backend) -> dict:
+    """Convert the frontend camera dict into OpenCVCameraConfig objects.
+
+    `backend` (a Cv2Backends name) and `fourcc` (a 4-char code) are optional per
+    camera; when omitted they fall back to `default_backend` and auto-detect.
+    """
+    from lerobot.cameras.configs import Cv2Backends
+    from lerobot.cameras.opencv import OpenCVCameraConfig
+
+    camera_configs: dict = {}
+    for camera_name, camera_data in cameras.items():
+        if camera_data.get("type") != "opencv":
+            logger.warning(
+                f"⚠️ CAMERA CONFIG: Unsupported camera type '{camera_data.get('type')}' for {camera_name}"
+            )
+            continue
+
+        backend_name = camera_data.get("backend")
+        backend = Cv2Backends[backend_name] if backend_name else default_backend
+        fourcc = camera_data.get("fourcc") or None
+
+        camera_configs[camera_name] = OpenCVCameraConfig(
+            index_or_path=camera_data.get("camera_index", 0),
+            backend=backend,
+            fps=camera_data.get("fps"),
+            width=camera_data.get("width"),
+            height=camera_data.get("height"),
+            fourcc=fourcc,
+        )
+        logger.info(
+            f"✅ CAMERA CONFIG: {camera_name} -> OpenCVCameraConfig("
+            f"index={camera_data.get('camera_index')}, backend={backend.name}, "
+            f"{camera_data.get('width')}x{camera_data.get('height')}@{camera_data.get('fps')}fps, "
+            f"fourcc={fourcc})"
+        )
+    return camera_configs
+
+
+def create_record_config(request: RecordingRequest) -> RecordConfig:
+    """Create a RecordConfig from the recording request"""
     # Setup calibration files
     leader_config_name, follower_config_name = setup_calibration_files(
         request.leader_config, request.follower_config
     )
 
-    # 🔧 CAMERA CONFIG CONVERSION: Convert frontend camera dict to proper CameraConfig objects
-    camera_configs = {}
-    for camera_name, camera_data in request.cameras.items():
-        if camera_data.get("type") == "opencv":
-            # Convert frontend format to OpenCVCameraConfig
-            camera_configs[camera_name] = OpenCVCameraConfig(
-                index_or_path=camera_data.get("camera_index", 0),
-                backend=opencv_backend,
-                fps=camera_data.get("fps"),
-                width=camera_data.get("width"),
-                height=camera_data.get("height"),
-            )
-            logger.info(
-                f"✅ CAMERA CONFIG: Converted {camera_name} -> OpenCVCameraConfig(index={camera_data.get('camera_index')}, backend={opencv_backend.name}, {camera_data.get('width')}x{camera_data.get('height')}@{camera_data.get('fps')}fps)"
-            )
-        else:
-            logger.warning(
-                f"⚠️ CAMERA CONFIG: Unsupported camera type '{camera_data.get('type')}' for {camera_name}"
-            )
+    # Convert the frontend camera dict into OpenCVCameraConfig objects. Backend
+    # defaults to the platform pin unless the request overrides it per camera.
+    camera_configs = _build_camera_configs(request.cameras, _platform_backend())
 
     # Create robot config
     robot_config = SO101FollowerConfig(

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -68,3 +68,54 @@ def test_create_record_config_pins_dshow_on_windows(monkeypatch: pytest.MonkeyPa
 
     config = record.create_record_config(request)
     assert config.robot.cameras["wrist"].backend == Cv2Backends.DSHOW
+
+
+def test_build_camera_configs_uses_default_backend_when_unset() -> None:
+    from lelab.record import _build_camera_configs
+    from lerobot.cameras.configs import Cv2Backends
+
+    cameras = {"cam": {"type": "opencv", "camera_index": 0, "width": 640, "height": 480, "fps": 30}}
+    configs = _build_camera_configs(cameras, Cv2Backends.AVFOUNDATION)
+
+    assert configs["cam"].backend == Cv2Backends.AVFOUNDATION
+    assert configs["cam"].fourcc is None
+    assert configs["cam"].index_or_path == 0
+
+
+def test_build_camera_configs_passes_fourcc_through() -> None:
+    from lelab.record import _build_camera_configs
+    from lerobot.cameras.configs import Cv2Backends
+
+    cameras = {"cam": {"type": "opencv", "camera_index": 0, "fourcc": "MJPG"}}
+    configs = _build_camera_configs(cameras, Cv2Backends.ANY)
+
+    assert configs["cam"].fourcc == "MJPG"
+
+
+def test_build_camera_configs_explicit_backend_overrides_default() -> None:
+    from lelab.record import _build_camera_configs
+    from lerobot.cameras.configs import Cv2Backends
+
+    cameras = {"cam": {"type": "opencv", "camera_index": 0, "backend": "V4L2"}}
+    configs = _build_camera_configs(cameras, Cv2Backends.AVFOUNDATION)
+
+    assert configs["cam"].backend == Cv2Backends.V4L2
+
+
+def test_build_camera_configs_invalid_backend_raises() -> None:
+    from lelab.record import _build_camera_configs
+    from lerobot.cameras.configs import Cv2Backends
+
+    cameras = {"cam": {"type": "opencv", "camera_index": 0, "backend": "NOPE"}}
+    with pytest.raises(KeyError):
+        _build_camera_configs(cameras, Cv2Backends.ANY)
+
+
+def test_build_camera_configs_skips_non_opencv_type() -> None:
+    from lelab.record import _build_camera_configs
+    from lerobot.cameras.configs import Cv2Backends
+
+    cameras = {"cam": {"type": "realsense", "camera_index": 0}}
+    configs = _build_camera_configs(cameras, Cv2Backends.ANY)
+
+    assert configs == {}


### PR DESCRIPTION
## Summary

Exposes two OpenCV camera parameters — **FOURCC** (pixel format, e.g. `MJPG`/`YUYV`) and **backend** (`Cv2Backends`) — per camera in the recording UI, folded into a collapsed-by-default **Configuration** section on each camera card.

- **Frontend** (`frontend/src/components/recording/CameraConfiguration.tsx`): `CameraConfig` gains optional `fourcc?`/`backend?`. Each camera card's Resolution/FPS plus two new dropdowns (FOURCC: `Auto` + presets; Backend: `Default` + the full `Cv2Backends` list) now live inside a `Collapsible` that starts closed. A hint warns that overriding the backend can reorder camera indices on macOS.
- **Serialization** (`frontend/src/pages/Landing.tsx`): `fourcc`/`backend` are added to the recording request only when set — leaving `Auto`/`Default` omits them entirely, so the backend keeps today's auto-detect + platform-pinned behavior.
- **Backend** (`lelab/record.py`): the camera-conversion + platform-backend logic is extracted into pure helpers `_platform_backend()` and `_build_camera_configs()`. The latter honors per-camera `fourcc` (passed through, else `None`) and `backend` (resolved via `Cv2Backends[name]`, else the platform default).

The frontend `BACKEND_OPTIONS` names exactly match the `Cv2Backends` members the backend resolves, so the UI can never emit a value that `KeyError`s.

## Notes

- `frontend/dist/` is intentionally **not** rebuilt in this PR — `origin/main` just bumped vite 5→8, and `build_frontend.yml` rebuilds the bundle on merge to `main`. Building it here would ship a toolchain-mismatched bundle.

## Test Plan

- [x] `pytest` — 104 passing, incl. 5 new tests for `_build_camera_configs` (default backend, fourcc passthrough, explicit-backend override, invalid-backend KeyError, non-opencv skip)
- [x] `ruff check`, `tsc --noEmit`, `eslint` — clean
- [x] `npm run build` — production bundle builds clean
- [x] **Live hardware check** (needs SO-101 + cameras): expand a camera's Configuration section, set FOURCC=MJPG / Backend=AVFOUNDATION, start a recording, and confirm the `✅ CAMERA CONFIG:` log reports the chosen values; a second camera left at Auto/Default logs the platform backend + `fourcc=None`.