### PR TITLE
fix(server): reject unsafe names on calibration-config delete

### DIFF
--- a/lelab/server.py
+++ b/lelab/server.py
@@ -807,6 +807,13 @@ def delete_calibration_config(device_type: str, config_name: str):
         else:
             return {"success": False, "message": "Invalid device type"}
 
+        # config_name is interpolated into a filename, so reject path-traversal
+        # characters (/, \, ..) before touching the filesystem. Defense-in-depth:
+        # FastAPI path params already block a literal "/", but not "\" or "..".
+        # Reuses the same guard already applied to robot-record deletes.
+        if not is_valid_robot_name(config_name):
+            return {"success": False, "message": "Invalid configuration name"}
+
         # Construct the file path
         filename = f"{config_name}.json"
         file_path = os.path.join(config_path, filename)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -69,6 +69,18 @@ def test_unknown_route_returns_404(client: TestClient) -> None:
     assert response.status_code == 404
 
 
+@pytest.mark.parametrize("unsafe_name", ["evil..name", "..config", "back\\door"])
+def test_delete_calibration_config_rejects_unsafe_name(client: TestClient, unsafe_name: str) -> None:
+    """A config name with path-traversal characters is rejected before any
+    filesystem access — distinct from the "not found" path, so the guard is
+    proven to fire. The validator also blocks "/" and "\\"."""
+    response = client.delete(f"/calibration-configs/teleop/{unsafe_name}")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is False
+    assert "Invalid configuration name" in body["message"]
+
+
 def _spa_mounted(client: TestClient) -> bool:
     return any(getattr(route, "name", None) == "frontend" for route in client.app.routes)
 


### PR DESCRIPTION
## What does this PR do?

Adds input validation to the calibration-config delete endpoint so a config
name can't steer the file deletion outside the config directory.

## The issue

`DELETE /calibration-configs/{device_type}/{config_name}` builds a filename
straight from `config_name` and calls `os.remove`, with no validation:

```python
filename = f"{config_name}.json"
file_path = os.path.join(config_path, filename)
...
os.remove(file_path)
```

`device_type` is whitelisted (`robot` / `teleop`), but `config_name` is not. A
value containing `\` or `..` could point `os.remove` outside the intended
directory. FastAPI path params already block a literal `/`, but not `\` or
`..`, so this is defense-in-depth plus consistency — the robot-record delete
endpoints already guard their name with `is_valid_robot_name()`; this one was
the odd one out.

## The fix

Apply the existing `is_valid_robot_name()` guard (which rejects empty names,
leading/trailing whitespace, and any `/`, `\`, or `..`) to `config_name`
before constructing the path:

```python
if not is_valid_robot_name(config_name):
    return {"success": False, "message": "Invalid configuration name"}
```

No new helper, no behavior change for valid names; just the same safety check
already used elsewhere, applied consistently.

## Testing

Adds a parametrized regression test in `tests/test_server.py` asserting that
unsafe names ie both `..` variants and a backslash (`back\door`, the realistic
routed escape on Windows) are rejected with `Invalid configuration name`, a
distinct response from "not found", so the guard is proven to fire rather than
just hitting a missing file. `is_valid_robot_name`'s rejection of `/`, `\`, and
`..` is also covered at the unit level in `tests/test_utils_config.py`.
`pytest` and `pre-commit` (ruff, mypy, bandit, …) pass locally.
