### PR TITLE
fix(teleop): report connection failures and stop cleanly on exit

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import Upload from "@/pages/Upload";
 
 import NotFound from "@/pages/NotFound";
 import SingleTabGuard from "@/components/SingleTabGuard";
+import TeleopStopNotice from "@/components/TeleopStopNotice";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { ApiProvider } from "./contexts/ApiContext";
 import { HfAuthProvider } from "./contexts/HfAuthContext";
@@ -32,6 +33,7 @@ function App() {
                 <DragAndDropProvider>
                   <BrowserRouter>
                     <SingleTabGuard>
+                      <TeleopStopNotice />
                       <Routes>
                         <Route path="/" element={<Landing />} />
                         <Route path="/teleoperation" element={<Teleoperation />} />

--- a/frontend/src/components/TeleopStopNotice.tsx
+++ b/frontend/src/components/TeleopStopNotice.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { useToast } from "@/hooks/use-toast";
+
+const FLAG = "lelab:teleop-stopped";
+
+/**
+ * One-time confirmation that teleoperation was stopped during the previous
+ * page's unload (a browser navigation, reload, or tab close from the
+ * teleoperation page set a sessionStorage flag, since React cleanup can't run
+ * in those cases). On the next fresh load we surface a toast wherever the user
+ * landed, then clear the flag. In-app navigation away from teleop toasts
+ * directly and never sets the flag, so this never double-fires.
+ */
+const TeleopStopNotice = () => {
+  const { toast } = useToast();
+
+  useEffect(() => {
+    let stopped = false;
+    try {
+      stopped = sessionStorage.getItem(FLAG) === "1";
+      if (stopped) sessionStorage.removeItem(FLAG);
+    } catch {
+      /* sessionStorage unavailable — nothing to show */
+    }
+    if (stopped) {
+      toast({
+        title: "Teleoperation stopped",
+        description: "The arm was disconnected cleanly when you left the page.",
+      });
+    }
+  }, [toast]);
+
+  return null;
+};
+
+export default TeleopStopNotice;

--- a/frontend/src/components/landing/RobotConfigManager.tsx
+++ b/frontend/src/components/landing/RobotConfigManager.tsx
@@ -45,7 +45,10 @@ const RobotConfigManager: React.FC<RobotConfigManagerProps> = ({
         }),
       });
       const data = await res.json();
-      if (res.ok) {
+      // The backend returns HTTP 200 with `{ success: false }` for logical
+      // failures (arm not connected, already active), so gate on `data.success`
+      // — not just `res.ok` — or we'd navigate to an empty teleop screen.
+      if (res.ok && data.success) {
         toast({
           title: "Teleoperation Started",
           description: data.message || `Started teleoperation for ${robot.name}.`,

--- a/frontend/src/pages/Teleoperation.tsx
+++ b/frontend/src/pages/Teleoperation.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import VisualizerPanel from "@/components/control/VisualizerPanel";
 import { useToast } from "@/hooks/use-toast";
@@ -9,47 +9,61 @@ const TeleoperationPage = () => {
   const { toast } = useToast();
   const { baseUrl, fetchWithHeaders } = useApi();
 
-  const handleGoBack = async () => {
+  // Stop teleoperation exactly once, however the user leaves, so the back
+  // button, an in-app link, and the unmount safety net can't double-stop or
+  // double-toast.
+  const stoppedRef = useRef(false);
+  const stopTeleoperation = useCallback(async () => {
+    if (stoppedRef.current) return;
+    stoppedRef.current = true;
     try {
-      // Stop the teleoperation process before navigating back
-      console.log("🛑 Stopping teleoperation...");
-      const response = await fetchWithHeaders(`${baseUrl}/stop-teleoperation`, {
+      const res = await fetchWithHeaders(`${baseUrl}/stop-teleoperation`, {
         method: "POST",
       });
-
-      if (response.ok) {
-        const result = await response.json();
-        console.log("✅ Teleoperation stopped:", result.message);
+      const data = await res.json();
+      if (data?.success) {
         toast({
-          title: "Teleoperation Stopped",
-          description:
-            result.message ||
-            "Robot teleoperation has been stopped successfully.",
-        });
-      } else {
-        const errorText = await response.text();
-        console.warn(
-          "⚠️ Failed to stop teleoperation:",
-          response.status,
-          errorText
-        );
-        toast({
-          title: "Warning",
-          description: `Failed to stop teleoperation properly. Status: ${response.status}`,
-          variant: "destructive",
+          title: "Teleoperation stopped",
+          description: "The arm was disconnected cleanly.",
         });
       }
-    } catch (error) {
-      console.error("❌ Error stopping teleoperation:", error);
-      toast({
-        title: "Error",
-        description: "Failed to communicate with the robot server.",
-        variant: "destructive",
-      });
-    } finally {
-      // Navigate back regardless of the result
-      navigate("/");
+    } catch {
+      /* best-effort */
     }
+  }, [baseUrl, fetchWithHeaders, toast]);
+
+  // Cover every exit path so a session can't keep running and block the next
+  // start with "already active":
+  //   - the back button awaits stopTeleoperation() then navigates (below);
+  //   - any other in-app navigation unmounts this component → stop via cleanup;
+  //   - a browser-level leave (URL change, reload, tab close) never runs React
+  //     cleanup, so `pagehide` fires a keepalive stop that survives the unload
+  //     and stashes a flag the next page reads to confirm the clean disconnect.
+  //     It uses a bare fetch (no JSON Content-Type) so the request stays a CORS
+  //     "simple request" and isn't dropped to a preflight mid-unload.
+  useEffect(() => {
+    const handlePageHide = () => {
+      try {
+        sessionStorage.setItem("lelab:teleop-stopped", "1");
+      } catch {
+        /* sessionStorage may be unavailable; the stop below still runs */
+      }
+      fetch(`${baseUrl}/stop-teleoperation`, {
+        method: "POST",
+        keepalive: true,
+      }).catch(() => {});
+    };
+    window.addEventListener("pagehide", handlePageHide);
+
+    return () => {
+      window.removeEventListener("pagehide", handlePageHide);
+      stopTeleoperation();
+    };
+  }, [baseUrl, stopTeleoperation]);
+
+  const handleGoBack = async () => {
+    await stopTeleoperation();
+    navigate("/");
   };
 
   return (

--- a/lelab/teleoperate.py
+++ b/lelab/teleoperate.py
@@ -122,8 +122,28 @@ def get_joint_positions_from_robot(robot) -> dict[str, float]:
         return dict.fromkeys(motor_to_urdf_mapping.values(), 0.0)
 
 
+def _safe_disconnect(device) -> None:
+    """Disconnect a robot/teleop device, swallowing (but logging) any error.
+
+    Used on the connection-failure cleanup path so one device's failure can't
+    leave the other holding its serial port open.
+    """
+    if device is None:
+        return
+    try:
+        device.disconnect()
+    except Exception as e:
+        logger.warning(f"Error disconnecting device during cleanup: {e}")
+
+
 def handle_start_teleoperation(request: TeleoperateRequest, websocket_manager=None) -> dict[str, Any]:
-    """Handle start teleoperation request"""
+    """Handle start teleoperation request.
+
+    Connects to both arms *synchronously* so that a connection failure (arm
+    unplugged, port busy, power off) is reported back to the caller, rather than
+    dying silently in the worker thread while the API has already claimed
+    success. Only the teleoperation loop runs in the background thread.
+    """
     global teleoperation_active, teleoperation_thread, current_robot, current_teleop
 
     from . import record as _record, rollout as _rollout
@@ -137,6 +157,8 @@ def handle_start_teleoperation(request: TeleoperateRequest, websocket_manager=No
             return {"success": False, "message": "Inference is currently active. Stop it first."}
         teleoperation_active = True
 
+    robot = None
+    teleop_device = None
     try:
         logger.info(
             f"Starting teleoperation with leader port: {request.leader_port}, follower port: {request.follower_port}"
@@ -158,72 +180,85 @@ def handle_start_teleoperation(request: TeleoperateRequest, websocket_manager=No
             id=leader_config_name,
         )
 
-        # Start teleoperation in a separate thread
+        # Connect synchronously. If either device fails to connect, clean up the
+        # other (so its serial port is released) and report the error — do NOT
+        # leave the caller thinking teleoperation started.
+        logger.info("Initializing robot and teleop device...")
+        robot = SO101Follower(robot_config)
+        teleop_device = SO101Leader(teleop_config)
+
+        # Connect each arm separately so the error names which one failed and
+        # tells the user what to do, instead of a generic "failed to start".
+        logger.info("Connecting to follower arm...")
+        try:
+            robot.bus.connect()
+        except Exception as e:
+            raise RuntimeError(
+                f"Could not connect to the follower arm on {request.follower_port}. "
+                "Make sure it's plugged in and powered on, then try again."
+            ) from e
+
+        logger.info("Connecting to leader arm...")
+        try:
+            teleop_device.bus.connect()
+        except Exception as e:
+            raise RuntimeError(
+                f"Could not connect to the leader arm on {request.leader_port}. "
+                "Make sure it's plugged in and powered on, then try again."
+            ) from e
+
+        # Write calibration to motors' memory
+        logger.info("Writing calibration to motors...")
+        robot.bus.write_calibration(robot.calibration)
+        teleop_device.bus.write_calibration(teleop_device.calibration)
+
+        # Connect cameras and configure motors
+        logger.info("Connecting cameras and configuring motors...")
+        for cam in robot.cameras.values():
+            cam.connect()
+        robot.configure()
+        teleop_device.configure()
+        logger.info("Successfully connected to both devices")
+
+        current_robot = robot
+        current_teleop = teleop_device
+
+        # Stream the arms in the background; the worker owns disconnect so stop()
+        # does not race the serial bus from the request thread.
         def teleoperation_worker():
             global teleoperation_active, current_robot, current_teleop
 
+            logger.info("Starting teleoperation loop...")
             try:
-                logger.info("Initializing robot and teleop device...")
-                robot = SO101Follower(robot_config)
-                teleop_device = SO101Leader(teleop_config)
+                last_broadcast_time = 0
+                broadcast_interval = 0.05  # 20 FPS
 
-                current_robot = robot
-                current_teleop = teleop_device
+                while teleoperation_active:
+                    action = teleop_device.get_action()
+                    robot.send_action(action)
 
-                logger.info("Connecting to devices...")
-                robot.bus.connect()
-                teleop_device.bus.connect()
+                    current_time = time.time()
+                    if current_time - last_broadcast_time >= broadcast_interval:
+                        try:
+                            joint_positions = get_joint_positions_from_robot(robot)
+                            joint_data = {
+                                "type": "joint_update",
+                                "joints": joint_positions,
+                                "timestamp": current_time,
+                            }
+                            if websocket_manager and websocket_manager.active_connections:
+                                websocket_manager.broadcast_joint_data_sync(joint_data)
+                            last_broadcast_time = current_time
+                        except Exception as e:
+                            logger.error(f"Error broadcasting joint data: {e}")
 
-                # Write calibration to motors' memory
-                logger.info("Writing calibration to motors...")
-                robot.bus.write_calibration(robot.calibration)
-                teleop_device.bus.write_calibration(teleop_device.calibration)
-
-                # Connect cameras and configure motors
-                logger.info("Connecting cameras and configuring motors...")
-                for cam in robot.cameras.values():
-                    cam.connect()
-                robot.configure()
-                teleop_device.configure()
-                logger.info("Successfully connected to both devices")
-
-                logger.info("Starting teleoperation loop...")
-
-                try:
-                    last_broadcast_time = 0
-                    broadcast_interval = 0.05  # 20 FPS
-
-                    while teleoperation_active:
-                        action = teleop_device.get_action()
-                        robot.send_action(action)
-
-                        current_time = time.time()
-                        if current_time - last_broadcast_time >= broadcast_interval:
-                            try:
-                                joint_positions = get_joint_positions_from_robot(robot)
-                                joint_data = {
-                                    "type": "joint_update",
-                                    "joints": joint_positions,
-                                    "timestamp": current_time,
-                                }
-                                if websocket_manager and websocket_manager.active_connections:
-                                    websocket_manager.broadcast_joint_data_sync(joint_data)
-                                last_broadcast_time = current_time
-                            except Exception as e:
-                                logger.error(f"Error broadcasting joint data: {e}")
-
-                        time.sleep(0.001)
-                finally:
-                    robot.disconnect()
-                    teleop_device.disconnect()
-                    logger.info("Teleoperation stopped")
-
-                return {"success": True, "message": "Teleoperation completed successfully"}
-
+                    time.sleep(0.001)
             except Exception as e:
-                logger.error(f"Error during teleoperation: {e}")
-                return {"success": False, "error": str(e)}
+                logger.error(f"Error during teleoperation loop: {e}")
             finally:
+                _safe_disconnect(robot)
+                _safe_disconnect(teleop_device)
+                logger.info("Teleoperation stopped")
                 teleoperation_active = False
                 current_robot = None
                 current_teleop = None
@@ -241,9 +276,17 @@ def handle_start_teleoperation(request: TeleoperateRequest, websocket_manager=No
         }
 
     except Exception as e:
+        # Connection (or setup) failed before the loop started: release any
+        # device that did open, reset state, and surface the error.
+        _safe_disconnect(robot)
+        _safe_disconnect(teleop_device)
         teleoperation_active = False
+        current_robot = None
+        current_teleop = None
         logger.error(f"Failed to start teleoperation: {e}")
-        return {"success": False, "message": f"Failed to start teleoperation: {str(e)}"}
+        # str(e) is already a user-facing message for the connection failures
+        # raised above; the toast title supplies the "error starting" context.
+        return {"success": False, "message": str(e)}
 
 
 def handle_stop_teleoperation() -> dict[str, Any]:

--- a/tests/test_teleoperate.py
+++ b/tests/test_teleoperate.py
@@ -49,3 +49,105 @@ def test_get_joint_positions_from_robot_uses_provided_object() -> None:
     robot.connect()
     positions = get_joint_positions_from_robot(robot)
     assert isinstance(positions, dict)
+
+
+def test_start_teleoperation_reports_connection_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A device that fails to connect must make the start handler return
+    success=False (so the UI surfaces the error and doesn't navigate to an
+    empty teleop screen) and reset state so a retry isn't blocked. Previously
+    the connect ran in a worker thread and the handler always claimed success.
+    """
+    import lelab.teleoperate as teleop
+
+    monkeypatch.setattr(teleop, "teleoperation_active", False)
+    monkeypatch.setattr(teleop, "setup_calibration_files", lambda leader, follower: ("leader", "follower"))
+
+    class _Bus:
+        def connect(self) -> None:
+            raise RuntimeError("serial port unavailable")
+
+    class _Device:
+        def __init__(self, config) -> None:
+            self.bus = _Bus()
+            self.cameras: dict = {}
+            self.disconnected = False
+
+        def disconnect(self) -> None:
+            self.disconnected = True
+
+    monkeypatch.setattr(teleop, "SO101Follower", _Device)
+    monkeypatch.setattr(teleop, "SO101Leader", _Device)
+
+    request = teleop.TeleoperateRequest(
+        leader_port="COM_LEADER",
+        follower_port="COM_FOLLOWER",
+        leader_config="leader",
+        follower_config="follower",
+    )
+    result = teleop.handle_start_teleoperation(request)
+
+    assert result["success"] is False
+    # The message must name the arm that failed (the follower connects first).
+    assert "follower" in result["message"].lower()
+    assert "COM_FOLLOWER" in result["message"]
+    # State must be reset so the next attempt isn't blocked by the mutex.
+    assert teleop.teleoperation_active is False
+
+
+def test_start_teleoperation_disconnects_follower_when_leader_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The partial-connect path: if the follower connects but the leader then
+    fails, the follower must be disconnected so its serial port is released.
+    """
+    import lelab.teleoperate as teleop
+
+    monkeypatch.setattr(teleop, "teleoperation_active", False)
+    monkeypatch.setattr(teleop, "setup_calibration_files", lambda leader, follower: ("leader", "follower"))
+
+    class _OkBus:
+        def connect(self) -> None:
+            pass
+
+    class _FailingBus:
+        def connect(self) -> None:
+            raise RuntimeError("leader offline")
+
+    class _Follower:
+        def __init__(self, config) -> None:
+            self.bus = _OkBus()
+            self.cameras: dict = {}
+            self.disconnected = False
+
+        def disconnect(self) -> None:
+            self.disconnected = True
+
+    class _Leader:
+        def __init__(self, config) -> None:
+            self.bus = _FailingBus()
+            self.disconnected = False
+
+        def disconnect(self) -> None:
+            self.disconnected = True
+
+    created: dict = {}
+    monkeypatch.setattr(
+        teleop, "SO101Follower", lambda config: created.setdefault("follower", _Follower(config))
+    )
+    monkeypatch.setattr(teleop, "SO101Leader", lambda config: created.setdefault("leader", _Leader(config)))
+
+    request = teleop.TeleoperateRequest(
+        leader_port="COM_LEADER",
+        follower_port="COM_FOLLOWER",
+        leader_config="leader",
+        follower_config="follower",
+    )
+    result = teleop.handle_start_teleoperation(request)
+
+    assert result["success"] is False
+    assert "leader" in result["message"].lower()
+    # The already-connected follower must have been cleaned up.
+    assert created["follower"].disconnected is True
+    assert teleop.teleoperation_active is False


### PR DESCRIPTION
Fixes #24 

## What does this PR do?

Makes teleoperation honest about whether it actually started, and stops the
session when the user leaves the page. Two user-visible bugs:

1. Starting teleoperation always succeeded and navigated to the teleop screen,
   even when no arm was connected.
2. Leaving the teleop page by anything other than the in-app back button left the
   session running, so the next start failed with "Teleoperation is already
   active".

## The bug

- Backend reported success before connecting - `handle_start_teleoperation`
  spawned a worker thread that did the real `bus.connect()`, and returned
  `{"success": true}` *immediately*. A failed connect was caught and only logged.
  (Plus a cleanup gap: a follower that connected before the leader failed was
  never disconnected, holding its port.)
- Frontend only checked the HTTP status - `handleTeleop` navigated on
  `if (res.ok)`, but the endpoint returns HTTP 200 with `{"success": false}` for
  logical failures so it navigated regardless of `data.success`.
- Teleop session leaked on exit - Stop was only wired to the on-screen back
  button, so URL navigation / reload / tab close never stopped it.

## The fix

Backend (`lelab/teleoperate.py`)
- Connect to both arms synchronously before returning, so a failure is
  reported to the caller as `success: false` with a message that names the arm
  that failed (leader vs follower) and how to retry. Only the streaming loop
  runs in the background thread.
- Add `_safe_disconnect()` and use it to release a partially-connected device on
  failure (and in the worker's cleanup), so a serial port is never left held.

Frontend
- Gate teleop navigation on `data.success`, not just `res.ok`; failures now show
  an error toast and keep the user on the landing page.
- Stop teleoperation on every exit from the teleop page:
  - in-app navigation → React unmount cleanup (stops + toasts immediately);
  - browser-level leave (URL change, reload, tab close) → a `pagehide` keepalive
    request that survives the unload, plus a `sessionStorage` flag that a small
    top-level `TeleopStopNotice` reads on the next load to confirm the clean
    disconnect wherever the user lands.

## Before / after

| Action | Before | After |
| --- | --- | --- |
| Start with arm unplugged | "success", teleop screen with robot | error toast naming the missing arm; stays on landing |
| Start with arm connected | works | works (now connects before responding) |
| Leave teleop via URL / reload / tab close | session keeps running → next start "already active" | session stops cleanly; confirmation shown |
| Leave teleop via back button | stops | stops (+ toast) |

### Image of failed connection when an arm is not connected -
<img width="1263" height="693" alt="image" src="https://github.com/user-attachments/assets/93c9c02b-11eb-4c7e-a272-69d23e9bf7b4" />

## Testing

- Adds two regression tests (`tests/test_teleoperate.py`): one mocks a device
  whose connect raises and asserts the start handler returns `success: false`
  with a message naming the failed arm and resets state so a retry isn't
  blocked; the other covers the partial-connect path (follower connects, leader
  fails) and asserts the already-connected follower is disconnected so its port
  is released.
- `pytest` and `pre-commit` (ruff, mypy, bandit, …) pass; `npm run build` passes
  and the changed files pass ESLint:

      npx eslint src/pages/Teleoperation.tsx src/components/TeleopStopNotice.tsx \
        src/App.tsx src/components/landing/RobotConfigManager.tsx

- Verified manually on Windows with an SO-101 leader/follower: unplugged → clear
  error; connected → teleop works; every exit path (back button, browser back,
  URL navigation, reload) stops the session and shows the confirmation, and a
  subsequent start works without "already active".

## Out of scope for this bug
The robot tile still shows "Ready" based on configuration/calibration, not live
connection. A real "connected" indicator needs a non-intrusive connection check
and a robot-type-agnostic status model (to scale beyond SO-101 leader/follower);
noted in the issue as the broader goal.