### PR TITLE
fix(cameras): return real device names on Windows and Linux

### DIFF
--- a/lelab/record.py
+++ b/lelab/record.py
@@ -99,6 +99,10 @@ def create_record_config(request: RecordingRequest) -> RecordConfig:
         opencv_backend = Cv2Backends.AVFOUNDATION
     elif platform.system() == "Linux":
         opencv_backend = Cv2Backends.V4L2
+    elif platform.system() == "Windows":
+        # DirectShow, matching the order /available-cameras enumerates (via
+        # pygrabber) so a camera_index always opens the previewed device.
+        opencv_backend = Cv2Backends.DSHOW
     else:
         opencv_backend = Cv2Backends.ANY
 

--- a/lelab/server.py
+++ b/lelab/server.py
@@ -918,15 +918,77 @@ def _avfoundation_cameras_in_cv2_order() -> list[dict[str, Any]]:
         return []
 
 
+def _generic_cv2_cameras(backend) -> list[dict[str, Any]]:
+    """Last-resort enumeration: probe cv2 indices with placeholder names."""
+    import cv2
+
+    cameras: list[dict[str, Any]] = []
+    for i in range(10):
+        cap = cv2.VideoCapture(i, backend)
+        opened = cap.isOpened()
+        cap.release()
+        if opened:
+            cameras.append({"index": i, "name": f"Camera {i}", "available": True})
+    return cameras
+
+
+def _windows_cameras() -> list[dict[str, Any]]:
+    """Enumerate Windows cameras with their real DirectShow names.
+
+    pygrabber lists DirectShow video devices in the same order cv2's DSHOW
+    backend indexes them (which recording is pinned to), so the returned index
+    matches what ``cv2.VideoCapture(i, CAP_DSHOW)`` opens. The real names let the
+    frontend match each index to the browser's ``MediaDeviceInfo.label`` for the
+    live preview. Falls back to generic names if pygrabber is unavailable.
+    """
+    try:
+        from pygrabber.dshow_graph import FilterGraph
+
+        names = FilterGraph().get_input_devices()
+    except Exception as e:  # ImportError, or a COM/DirectShow failure
+        logger.warning("pygrabber unavailable; using generic camera names: %s", e)
+        import cv2
+
+        return _generic_cv2_cameras(cv2.CAP_DSHOW)
+    return [{"index": i, "name": name, "available": True} for i, name in enumerate(names)]
+
+
+def _v4l2_camera_name(index: int) -> str | None:
+    """Real camera name for /dev/video{index} from sysfs (Linux, no deps)."""
+    try:
+        with open(f"/sys/class/video4linux/video{index}/name", encoding="utf-8") as f:
+            return f.read().strip() or None
+    except OSError:
+        return None
+
+
+def _linux_cameras() -> list[dict[str, Any]]:
+    """Enumerate Linux cameras, naming each from sysfs (no extra deps)."""
+    import cv2
+
+    cameras: list[dict[str, Any]] = []
+    for i in range(10):
+        cap = cv2.VideoCapture(i, cv2.CAP_V4L2)
+        opened = cap.isOpened()
+        cap.release()
+        if not opened:
+            continue
+        cameras.append({"index": i, "name": _v4l2_camera_name(i) or f"Camera {i}", "available": True})
+    return cameras
+
+
 @app.get("/available-cameras")
 def get_available_cameras():
     """List cameras with the same index ordering cv2 will use to record.
 
-    On macOS we mirror OpenCV's AVFoundation enumeration via PyObjC so each
-    index comes with the AVFoundation ``localizedName``. The browser's
-    ``MediaDeviceInfo.label`` is that same ``localizedName``, so the
-    frontend can match by name to find the matching browser deviceId for the
-    live preview while we record by cv2 index.
+    Each platform enumerates in the order its cv2 backend indexes devices, and
+    pairs each index with the device's real name so the frontend can match it to
+    the browser's ``MediaDeviceInfo.label`` for the live preview:
+      - macOS: AVFoundation ``localizedName`` (via a PyObjC subprocess);
+      - Windows: DirectShow FriendlyName (via pygrabber; recording pinned DSHOW);
+      - Linux: the v4l2 device name from sysfs.
+    Without real names the frontend can't match a camera and shows "No browser
+    match" with an empty device_id (issues #12, #16).
     """
     try:
         import platform
@@ -938,27 +1000,14 @@ def get_available_cameras():
             for cam in cameras:
                 cam["available"] = True
             return {"status": "success", "cameras": cameras}
+        if system == "Windows":
+            return {"status": "success", "cameras": _windows_cameras()}
+        if system == "Linux":
+            return {"status": "success", "cameras": _linux_cameras()}
 
-        # Linux / others: fall back to the cv2 probe (no friendly names).
         import cv2
 
-        backend = cv2.CAP_V4L2 if system == "Linux" else cv2.CAP_ANY
-
-        cameras = []
-        for i in range(10):
-            cap = cv2.VideoCapture(i, backend)
-            if not cap.isOpened():
-                cap.release()
-                continue
-            cameras.append(
-                {
-                    "index": i,
-                    "name": f"Camera {i}",
-                    "available": True,
-                }
-            )
-            cap.release()
-        return {"status": "success", "cameras": cameras}
+        return {"status": "success", "cameras": _generic_cv2_cameras(cv2.CAP_ANY)}
     except ImportError:
         logger.warning("OpenCV not available for camera detection")
         return {"status": "success", "cameras": []}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ dependencies = [
     "uvicorn>=0.24.0",
     "psutil>=5.9.0",
     "lerobot[core_scripts,feetech,training] @ git+https://github.com/huggingface/lerobot.git@82dffde7fad11cba91f7916b050fbe7d7eea35ab",
+    # Windows-only: real DirectShow camera names for /available-cameras so the
+    # frontend can match a camera to its browser deviceId (issues #12, #16).
+    # Guarded by try/except at the call site, so its absence degrades gracefully.
+    "pygrabber>=0.2 ; sys_platform == 'win32'",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -44,3 +44,27 @@ def test_handle_stop_recording_when_idle_returns_dict(tmp_lerobot_home) -> None:
 
     result = handle_stop_recording()
     assert isinstance(result, dict)
+
+
+def test_create_record_config_pins_dshow_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On Windows, recording must use the DSHOW backend so a camera_index opens
+    the same device /available-cameras enumerated (via pygrabber, DSHOW order).
+    """
+    import lelab.record as record
+    from lerobot.cameras.configs import Cv2Backends
+
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+    monkeypatch.setattr(record, "setup_calibration_files", lambda leader, follower: ("leader", "follower"))
+
+    request = record.RecordingRequest(
+        leader_port="COM_LEADER",
+        follower_port="COM_FOLLOWER",
+        leader_config="leader",
+        follower_config="follower",
+        dataset_repo_id="user/dataset",
+        single_task="pick up the cube",
+        cameras={"wrist": {"type": "opencv", "camera_index": 0, "width": 640, "height": 480, "fps": 30}},
+    )
+
+    config = record.create_record_config(request)
+    assert config.robot.cameras["wrist"].backend == Cv2Backends.DSHOW

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -148,3 +148,65 @@ def test_connection_manager_broadcast_sync_does_not_block_without_loop() -> None
     mgr = ConnectionManager()
     # Should enqueue without raising even if there are no consumers.
     mgr.broadcast_joint_data_sync({"shoulder_pan.pos": 1.0})
+
+
+def _install_fake_pygrabber(monkeypatch: pytest.MonkeyPatch, filter_graph_cls) -> None:
+    import sys
+    import types
+
+    module = types.ModuleType("pygrabber.dshow_graph")
+    module.FilterGraph = filter_graph_cls
+    monkeypatch.setitem(sys.modules, "pygrabber", types.ModuleType("pygrabber"))
+    monkeypatch.setitem(sys.modules, "pygrabber.dshow_graph", module)
+
+
+def test_windows_cameras_uses_real_directshow_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Windows path returns pygrabber's real device names in index order so
+    the frontend can match each camera to its browser deviceId (issues #12/#16).
+    """
+    from lelab import server
+
+    class _FakeGraph:
+        def get_input_devices(self) -> list[str]:
+            return ["USB2.0_CAM1", "ASUS FHD webcam"]
+
+    _install_fake_pygrabber(monkeypatch, _FakeGraph)
+
+    assert server._windows_cameras() == [
+        {"index": 0, "name": "USB2.0_CAM1", "available": True},
+        {"index": 1, "name": "ASUS FHD webcam", "available": True},
+    ]
+
+
+def test_windows_cameras_falls_back_when_pygrabber_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If pygrabber is missing or its COM init fails, enumeration degrades to the
+    generic cv2 probe instead of erroring."""
+    from lelab import server
+
+    class _BoomGraph:
+        def __init__(self) -> None:
+            raise RuntimeError("DirectShow/COM unavailable")
+
+    _install_fake_pygrabber(monkeypatch, _BoomGraph)
+    sentinel = [{"index": 0, "name": "Camera 0", "available": True}]
+    monkeypatch.setattr(server, "_generic_cv2_cameras", lambda backend: sentinel)
+
+    assert server._windows_cameras() == sentinel
+
+
+def test_v4l2_camera_name_reads_sysfs(monkeypatch: pytest.MonkeyPatch) -> None:
+    import io
+
+    from lelab import server
+
+    monkeypatch.setattr("builtins.open", lambda *a, **k: io.StringIO("HD Pro Webcam C920\n"))
+    assert server._v4l2_camera_name(0) == "HD Pro Webcam C920"
+
+
+def test_v4l2_camera_name_returns_none_when_missing() -> None:
+    from lelab import server
+
+    # No such sysfs node (also the case on non-Linux): graceful None, not error.
+    assert server._v4l2_camera_name(999999) is None


### PR DESCRIPTION
Fixes #12
Fixes #16

## What does this PR do?

`/available-cameras` returned placeholder names (`"Camera 0"`, `"Camera 1"`) on
Windows and Linux. The frontend matches a cv2 index to a browser `deviceId`
by name (the browser's `MediaDeviceInfo.label`), so a placeholder never
matched and the preview showed **"No browser match"** and the saved camera 
had an empty `device_id`. Only macOS worked, because it already returned real
AVFoundation names. Two independent reports: #12 and #16.

## The fix

Return each camera's real name, in the same order cv2 indexes it:

- Windows : read DirectShow FriendlyNames via **pygrabber** (new dependency), 
  which enumerates in the same order cv2's DSHOW backend indexes devices. 
  Windows recording is pinned to `DSHOW` so a `camera_index` opens the previewed
  device. pygrabber is imported under `try/except`, so if it's missing or COM
  init fails, enumeration falls back to the previous generic probe.
- Linux : read the v4l2 device name from `/sys/class/video4linux/video*/name`
  (stdlib only, no new dependency).
- macOS is unchanged.

With real names, the frontend's existing name-matching connects each camera to
its browser `deviceId` and the preview works.

## Dependency note

This adds **`pygrabber`** as a **Windows-only** dependency
(`pygrabber>=0.2 ; sys_platform == 'win32'`). Non-Windows installs get nothing
new, and the call site degrades gracefully if it's absent. I went ahead and
implemented it because two users (incl me) are blocked on Windows (#12, #16), a 
dep-free Windows path can't recover the cv2 index ordering reliably, and it's easy 
to adjust or revert. **Very happy to change the approach** (drop the dep, gate it
behind an extra, etc.) if you would prefer, just wanted to unblock with something
working and tested.

## Before/After

### Before the change
<img width="1271" height="698" alt="image" src="https://github.com/user-attachments/assets/7f8912f1-7a3d-42e6-9a5a-690322b260e5" />

### After the change for SO-101 wrist cam 
<img width="1268" height="700" alt="image" src="https://github.com/user-attachments/assets/35af5770-1a14-4e45-964d-0204db071229" />


## Testing

- Verified on Windows 11 with two cameras: `/available-cameras` now returns
  `"USB2.0_CAM1"` and `"ASUS FHD webcam"` (was `"Camera 0/1"`), the
  Calibration camera preview shows a live feed instead of "No browser match",
  and the saved camera has a real `device_id`.
- Added unit tests (mocked, so they run cross-platform): the Windows real-name
  path, the graceful fallback when pygrabber is unavailable, the Linux sysfs
  name lookup (present + missing), and that Windows recording is pinned to the
  DSHOW backend.
- `pytest tests/test_server.py tests/test_record.py`, `pre-commit`,
  `npm run build`, and the relevant ESLint checks pass locally.