### PR TITLE
fix(ci): bump Node to 22 for Vite 8 (dist rebuild workflow + Space Dockerfile)

### DIFF
--- a/.github/workflows/build_frontend.yml
+++ b/.github/workflows/build_frontend.yml
@@ -23,7 +23,9 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          # Vite 8 requires ^20.19.0 or >=22.12.0; on Node 18 `npm run build`
+          # fails, which silently stops dist from being rebuilt.
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
       - name: Install

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:18-alpine
+# Vite 8 requires Node ^20.19.0 or >=22.12.0; on Node 18 `npm run build` fails,
+# which is what breaks the Hugging Face Space build.
+FROM node:22-alpine
 
 # Use the existing node user (usually UID 1000)
 # Set up environment variables for the node user


### PR DESCRIPTION
## What does this PR do?

A Dependabot PR bumped the repo to **Vite 8** (`build(deps-dev): bump vite 5→8`),
which requires **Node `^20.19.0 || >=22.12.0`**. Two build pipelines were still
pinned to **Node 18**, so `npm run build` fails on both. This bumps both to
**Node 22**.

## The two breakages (same root cause)

**1. `.github/workflows/build_frontend.yml`** — the "Rebuild frontend/dist"
workflow. On Node 18 its build failed *silently* (a stale generated file, not a
red ❌), so the committed `frontend/dist` stopped being regenerated and the
shipped bundle fell behind the merged source — e.g. the **PR #21** calibration
UI never reached `dist`, so a plain `pip install` / `lelab` run still served the
old UI.

**2. `frontend/Dockerfile`** — the image the **Hugging Face Space** builds
(`FROM node:18-alpine`). Its `npm run build` step fails, so the Space currently
shows a **build error** and the live demo is down.

<img width="1276" height="332" alt="image" src="https://github.com/user-attachments/assets/65b65216-483d-4ea3-8412-f174dead1ecc" />

⚠️ **Worth flagging:** this is a Dependabot blind spot — the bot bumped the
build tool's Node requirement, but nothing bumped the `node-version` in CI or
the `node:18-alpine` base image, and the failures are easy to miss (a stale
file, and a Space build error on a separate runtime). It may be worth having
Dependabot also watch `actions/setup-node` / the Dockerfile base image so a
future build-tool bump can't silently desync these again.

## Notes

- The rebuild workflow also triggers on changes to **its own file**, so merging
  this re-runs it on Node 22 and regenerates `frontend/dist` from the current
  source — no hand-built `dist` is committed here.
- Verified the Vite 8 build passes on Node ≥20 locally; the Dockerfile change is
  the base-image tag only.