### PR TITLE
fix(space): install frontend deps from public npm registry

### DIFF
--- a/.github/workflows/lockfile_registry_guard.yml
+++ b/.github/workflows/lockfile_registry_guard.yml
@@ -1,0 +1,35 @@
+name: Lockfile registry guard
+
+# Fails fast if frontend/package-lock.json resolves packages from the internal
+# HF npm mirror (npm.registries.huggingface.tech). That mirror cannot serve the
+# full dependency set from the Space/CI Docker builders, so a lockfile pinned to
+# it hangs `npm ci` for ~8 min and then crashes ("Exit handler never called!").
+# Running `npm install` locally with a global ~/.npmrc pointing at the mirror is
+# what bakes those URLs in, so guard against it on every PR.
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/package-lock.json'
+      - '.github/workflows/lockfile_registry_guard.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/package-lock.json'
+      - '.github/workflows/lockfile_registry_guard.yml'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+      - name: Reject internal npm mirror URLs
+        run: |
+          if grep -q 'npm.registries.huggingface.tech' frontend/package-lock.json; then
+            echo "::error file=frontend/package-lock.json::Lockfile resolves from the internal HF npm mirror, which the Space/CI Docker build cannot fetch. Repoint it to the public registry and re-commit:"
+            echo "  sed -i 's#https://npm.registries.huggingface.tech/#https://registry.npmjs.org/#g' frontend/package-lock.json"
+            exit 1
+          fi
+          echo "OK: package-lock.json resolves from the public npm registry."

--- a/.github/workflows/lockfile_registry_guard.yml
+++ b/.github/workflows/lockfile_registry_guard.yml
@@ -1,5 +1,8 @@
 name: Lockfile registry guard
 
+permissions:
+  contents: read
+
 # Fails fast if frontend/package-lock.json resolves packages from the internal
 # HF npm mirror (npm.registries.huggingface.tech). That mirror cannot serve the
 # full dependency set from the Space/CI Docker builders, so a lockfile pinned to

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,4 @@
-# Vite 8 requires Node ^20.19.0 or >=22.12.0; on Node 18 `npm run build` fails,
-# which is what breaks the Hugging Face Space build.
+# Vite 8 requires Node ^20.19.0 or >=22.12.0.
 FROM node:22-alpine
 
 # Use the existing node user (usually UID 1000)
@@ -21,8 +20,10 @@ USER node
 # Copy package files (owned by node)
 COPY --chown=node:node package*.json ./
 
-# Install dependencies
-RUN npm install
+# Install dependencies straight from the committed lockfile. `npm ci` honours
+# the `resolved` URLs in package-lock.json and ignores the builder's configured
+# registry, so the install can't be derailed by a slow/incomplete npm mirror.
+RUN npm ci
 
 # Copy the entire viewer directory (owned by node)
 COPY --chown=node:node . .

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -85,7 +85,7 @@
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
-      "resolved": "https://npm.registries.huggingface.tech/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
       "license": "MIT",
       "engines": {
@@ -97,7 +97,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
-      "resolved": "https://npm.registries.huggingface.tech/@babel/runtime/-/runtime-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
@@ -106,13 +106,13 @@
     },
     "node_modules/@dimforge/rapier3d-compat": {
       "version": "0.12.0",
-      "resolved": "https://npm.registries.huggingface.tech/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
-      "resolved": "https://npm.registries.huggingface.tech/@emnapi/core/-/core-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
@@ -125,7 +125,7 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",
-      "resolved": "https://npm.registries.huggingface.tech/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
@@ -137,7 +137,7 @@
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
-      "resolved": "https://npm.registries.huggingface.tech/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
@@ -148,7 +148,7 @@
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
       "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "cpu": [
         "ppc64"
@@ -165,7 +165,7 @@
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
       "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "cpu": [
         "arm"
@@ -182,7 +182,7 @@
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
       "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "cpu": [
         "arm64"
@@ -199,7 +199,7 @@
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
       "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "cpu": [
         "x64"
@@ -216,7 +216,7 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
       "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
@@ -233,7 +233,7 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
       "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "cpu": [
         "x64"
@@ -250,7 +250,7 @@
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
       "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "cpu": [
         "arm64"
@@ -267,7 +267,7 @@
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
       "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "cpu": [
         "x64"
@@ -284,7 +284,7 @@
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
       "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "cpu": [
         "arm"
@@ -301,7 +301,7 @@
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
       "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "cpu": [
         "arm64"
@@ -318,7 +318,7 @@
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
       "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "cpu": [
         "ia32"
@@ -335,7 +335,7 @@
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
       "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "cpu": [
         "loong64"
@@ -352,7 +352,7 @@
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
       "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "cpu": [
         "mips64el"
@@ -369,7 +369,7 @@
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
       "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "cpu": [
         "ppc64"
@@ -386,7 +386,7 @@
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
       "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "cpu": [
         "riscv64"
@@ -403,7 +403,7 @@
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
       "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "cpu": [
         "s390x"
@@ -420,7 +420,7 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
       "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "cpu": [
         "x64"
@@ -437,7 +437,7 @@
     },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
       "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
       "cpu": [
         "arm64"
@@ -454,7 +454,7 @@
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
       "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "cpu": [
         "x64"
@@ -471,7 +471,7 @@
     },
     "node_modules/@esbuild/openbsd-arm64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
       "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
       "cpu": [
         "arm64"
@@ -488,7 +488,7 @@
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
       "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "cpu": [
         "x64"
@@ -505,7 +505,7 @@
     },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
       "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
       "cpu": [
         "arm64"
@@ -522,7 +522,7 @@
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
       "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "cpu": [
         "x64"
@@ -539,7 +539,7 @@
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
       "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "cpu": [
         "arm64"
@@ -556,7 +556,7 @@
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
       "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "cpu": [
         "ia32"
@@ -573,7 +573,7 @@
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
       "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "cpu": [
         "x64"
@@ -590,7 +590,7 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
-      "resolved": "https://npm.registries.huggingface.tech/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
@@ -609,7 +609,7 @@
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://npm.registries.huggingface.tech/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
@@ -622,7 +622,7 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
-      "resolved": "https://npm.registries.huggingface.tech/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
@@ -632,7 +632,7 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.21.2",
-      "resolved": "https://npm.registries.huggingface.tech/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
       "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -647,7 +647,7 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.4.2",
-      "resolved": "https://npm.registries.huggingface.tech/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
       "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -660,7 +660,7 @@
     },
     "node_modules/@eslint/core": {
       "version": "0.17.0",
-      "resolved": "https://npm.registries.huggingface.tech/@eslint/core/-/core-0.17.0.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -673,7 +673,7 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "3.3.5",
-      "resolved": "https://npm.registries.huggingface.tech/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
       "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
@@ -697,7 +697,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/globals/-/globals-14.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
@@ -710,7 +710,7 @@
     },
     "node_modules/@eslint/js": {
       "version": "9.39.4",
-      "resolved": "https://npm.registries.huggingface.tech/@eslint/js/-/js-9.39.4.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
       "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
@@ -723,7 +723,7 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "2.1.7",
-      "resolved": "https://npm.registries.huggingface.tech/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -733,7 +733,7 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.4.1",
-      "resolved": "https://npm.registries.huggingface.tech/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
       "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -747,7 +747,7 @@
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
-      "resolved": "https://npm.registries.huggingface.tech/@floating-ui/core/-/core-1.7.5.tgz",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
       "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "dependencies": {
@@ -756,7 +756,7 @@
     },
     "node_modules/@floating-ui/dom": {
       "version": "1.7.6",
-      "resolved": "https://npm.registries.huggingface.tech/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
       "dependencies": {
@@ -766,7 +766,7 @@
     },
     "node_modules/@floating-ui/react-dom": {
       "version": "2.1.8",
-      "resolved": "https://npm.registries.huggingface.tech/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
       "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
       "license": "MIT",
       "dependencies": {
@@ -779,13 +779,13 @@
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.11",
-      "resolved": "https://npm.registries.huggingface.tech/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
     "node_modules/@hookform/resolvers": {
       "version": "3.10.0",
-      "resolved": "https://npm.registries.huggingface.tech/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
       "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
       "license": "MIT",
       "peerDependencies": {
@@ -794,7 +794,7 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
-      "resolved": "https://npm.registries.huggingface.tech/@humanfs/core/-/core-0.19.2.tgz",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
       "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -807,7 +807,7 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.8",
-      "resolved": "https://npm.registries.huggingface.tech/@humanfs/node/-/node-0.16.8.tgz",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
       "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -822,7 +822,7 @@
     },
     "node_modules/@humanfs/types": {
       "version": "0.15.0",
-      "resolved": "https://npm.registries.huggingface.tech/@humanfs/types/-/types-0.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
       "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
       "dev": true,
       "license": "Apache-2.0",
@@ -832,7 +832,7 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -846,7 +846,7 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
-      "resolved": "https://npm.registries.huggingface.tech/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -860,7 +860,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://npm.registries.huggingface.tech/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "license": "MIT",
       "dependencies": {
@@ -870,7 +870,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://npm.registries.huggingface.tech/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "license": "MIT",
       "engines": {
@@ -879,13 +879,13 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://npm.registries.huggingface.tech/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://npm.registries.huggingface.tech/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "dependencies": {
@@ -895,13 +895,13 @@
     },
     "node_modules/@mediapipe/tasks-vision": {
       "version": "0.10.17",
-      "resolved": "https://npm.registries.huggingface.tech/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
       "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
       "license": "Apache-2.0"
     },
     "node_modules/@monogrid/gainmap-js": {
       "version": "3.4.0",
-      "resolved": "https://npm.registries.huggingface.tech/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
       "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
       "license": "MIT",
       "dependencies": {
@@ -913,7 +913,7 @@
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
-      "resolved": "https://npm.registries.huggingface.tech/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
@@ -932,7 +932,7 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://npm.registries.huggingface.tech/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "license": "MIT",
       "dependencies": {
@@ -945,7 +945,7 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://npm.registries.huggingface.tech/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "license": "MIT",
       "engines": {
@@ -954,7 +954,7 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://npm.registries.huggingface.tech/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "license": "MIT",
       "dependencies": {
@@ -967,7 +967,7 @@
     },
     "node_modules/@oxc-project/types": {
       "version": "0.133.0",
-      "resolved": "https://npm.registries.huggingface.tech/@oxc-project/types/-/types-0.133.0.tgz",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
       "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
@@ -977,19 +977,19 @@
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/number/-/number-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
       "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-accordion": {
       "version": "1.2.12",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
       "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
       "license": "MIT",
       "dependencies": {
@@ -1020,7 +1020,7 @@
     },
     "node_modules/@radix-ui/react-alert-dialog": {
       "version": "1.1.15",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
       "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
       "license": "MIT",
       "dependencies": {
@@ -1048,7 +1048,7 @@
     },
     "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
@@ -1066,7 +1066,7 @@
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
       "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
       "license": "MIT",
       "dependencies": {
@@ -1089,7 +1089,7 @@
     },
     "node_modules/@radix-ui/react-aspect-ratio": {
       "version": "1.1.8",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.8.tgz",
       "integrity": "sha512-5nZrJTF7gH+e0nZS7/QxFz6tJV4VimhQb1avEgtsJxvvIp5JilL+c58HICsKzPxghdwaDt48hEfPM1au4zGy+w==",
       "license": "MIT",
       "dependencies": {
@@ -1112,7 +1112,7 @@
     },
     "node_modules/@radix-ui/react-aspect-ratio/node_modules/@radix-ui/react-primitive": {
       "version": "2.1.4",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
       "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
       "license": "MIT",
       "dependencies": {
@@ -1135,7 +1135,7 @@
     },
     "node_modules/@radix-ui/react-avatar": {
       "version": "1.1.11",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-avatar/-/react-avatar-1.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.11.tgz",
       "integrity": "sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==",
       "license": "MIT",
       "dependencies": {
@@ -1162,7 +1162,7 @@
     },
     "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-context": {
       "version": "1.1.3",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
       "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
       "license": "MIT",
       "peerDependencies": {
@@ -1177,7 +1177,7 @@
     },
     "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-primitive": {
       "version": "2.1.4",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
       "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
       "license": "MIT",
       "dependencies": {
@@ -1200,7 +1200,7 @@
     },
     "node_modules/@radix-ui/react-checkbox": {
       "version": "1.3.3",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
       "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
       "license": "MIT",
       "dependencies": {
@@ -1230,7 +1230,7 @@
     },
     "node_modules/@radix-ui/react-collapsible": {
       "version": "1.1.12",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
       "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
       "license": "MIT",
       "dependencies": {
@@ -1260,7 +1260,7 @@
     },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.7",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
       "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
       "license": "MIT",
       "dependencies": {
@@ -1286,7 +1286,7 @@
     },
     "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
@@ -1304,7 +1304,7 @@
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
       "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
       "license": "MIT",
       "peerDependencies": {
@@ -1319,7 +1319,7 @@
     },
     "node_modules/@radix-ui/react-context": {
       "version": "1.1.2",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
       "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1334,7 +1334,7 @@
     },
     "node_modules/@radix-ui/react-context-menu": {
       "version": "2.2.16",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
       "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
       "license": "MIT",
       "dependencies": {
@@ -1362,7 +1362,7 @@
     },
     "node_modules/@radix-ui/react-dialog": {
       "version": "1.1.15",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
       "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
       "license": "MIT",
       "dependencies": {
@@ -1398,7 +1398,7 @@
     },
     "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
@@ -1416,7 +1416,7 @@
     },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
       "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
       "license": "MIT",
       "peerDependencies": {
@@ -1431,7 +1431,7 @@
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
       "version": "1.1.11",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
       "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
       "license": "MIT",
       "dependencies": {
@@ -1458,7 +1458,7 @@
     },
     "node_modules/@radix-ui/react-dropdown-menu": {
       "version": "2.1.16",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
       "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
       "license": "MIT",
       "dependencies": {
@@ -1487,7 +1487,7 @@
     },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
       "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
       "license": "MIT",
       "peerDependencies": {
@@ -1502,7 +1502,7 @@
     },
     "node_modules/@radix-ui/react-focus-scope": {
       "version": "1.1.7",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
       "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
       "license": "MIT",
       "dependencies": {
@@ -1527,7 +1527,7 @@
     },
     "node_modules/@radix-ui/react-hover-card": {
       "version": "1.1.15",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
       "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
       "license": "MIT",
       "dependencies": {
@@ -1558,7 +1558,7 @@
     },
     "node_modules/@radix-ui/react-id": {
       "version": "1.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
       "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
       "license": "MIT",
       "dependencies": {
@@ -1576,7 +1576,7 @@
     },
     "node_modules/@radix-ui/react-label": {
       "version": "2.1.8",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-label/-/react-label-2.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.8.tgz",
       "integrity": "sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==",
       "license": "MIT",
       "dependencies": {
@@ -1599,7 +1599,7 @@
     },
     "node_modules/@radix-ui/react-label/node_modules/@radix-ui/react-primitive": {
       "version": "2.1.4",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
       "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
       "license": "MIT",
       "dependencies": {
@@ -1622,7 +1622,7 @@
     },
     "node_modules/@radix-ui/react-menu": {
       "version": "2.1.16",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
       "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
       "license": "MIT",
       "dependencies": {
@@ -1662,7 +1662,7 @@
     },
     "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
@@ -1680,7 +1680,7 @@
     },
     "node_modules/@radix-ui/react-menubar": {
       "version": "1.1.16",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
       "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
       "license": "MIT",
       "dependencies": {
@@ -1712,7 +1712,7 @@
     },
     "node_modules/@radix-ui/react-navigation-menu": {
       "version": "1.2.14",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
       "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
       "license": "MIT",
       "dependencies": {
@@ -1748,7 +1748,7 @@
     },
     "node_modules/@radix-ui/react-popover": {
       "version": "1.1.15",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
       "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
       "license": "MIT",
       "dependencies": {
@@ -1785,7 +1785,7 @@
     },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
@@ -1803,7 +1803,7 @@
     },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.8",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
       "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
       "license": "MIT",
       "dependencies": {
@@ -1835,7 +1835,7 @@
     },
     "node_modules/@radix-ui/react-portal": {
       "version": "1.1.9",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
       "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
       "license": "MIT",
       "dependencies": {
@@ -1859,7 +1859,7 @@
     },
     "node_modules/@radix-ui/react-presence": {
       "version": "1.1.5",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
       "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
       "license": "MIT",
       "dependencies": {
@@ -1883,7 +1883,7 @@
     },
     "node_modules/@radix-ui/react-primitive": {
       "version": "2.1.3",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
       "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
       "license": "MIT",
       "dependencies": {
@@ -1906,7 +1906,7 @@
     },
     "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
@@ -1924,7 +1924,7 @@
     },
     "node_modules/@radix-ui/react-progress": {
       "version": "1.1.8",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-progress/-/react-progress-1.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.8.tgz",
       "integrity": "sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==",
       "license": "MIT",
       "dependencies": {
@@ -1948,7 +1948,7 @@
     },
     "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-context": {
       "version": "1.1.3",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
       "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
       "license": "MIT",
       "peerDependencies": {
@@ -1963,7 +1963,7 @@
     },
     "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-primitive": {
       "version": "2.1.4",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
       "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
       "license": "MIT",
       "dependencies": {
@@ -1986,7 +1986,7 @@
     },
     "node_modules/@radix-ui/react-radio-group": {
       "version": "1.3.8",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
       "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
       "license": "MIT",
       "dependencies": {
@@ -2018,7 +2018,7 @@
     },
     "node_modules/@radix-ui/react-roving-focus": {
       "version": "1.1.11",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
       "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
       "license": "MIT",
       "dependencies": {
@@ -2049,7 +2049,7 @@
     },
     "node_modules/@radix-ui/react-scroll-area": {
       "version": "1.2.10",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
       "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
       "license": "MIT",
       "dependencies": {
@@ -2080,7 +2080,7 @@
     },
     "node_modules/@radix-ui/react-select": {
       "version": "2.2.6",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
       "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
       "license": "MIT",
       "dependencies": {
@@ -2123,7 +2123,7 @@
     },
     "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
@@ -2141,7 +2141,7 @@
     },
     "node_modules/@radix-ui/react-separator": {
       "version": "1.1.8",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-separator/-/react-separator-1.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.8.tgz",
       "integrity": "sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==",
       "license": "MIT",
       "dependencies": {
@@ -2164,7 +2164,7 @@
     },
     "node_modules/@radix-ui/react-separator/node_modules/@radix-ui/react-primitive": {
       "version": "2.1.4",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
       "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
       "license": "MIT",
       "dependencies": {
@@ -2187,7 +2187,7 @@
     },
     "node_modules/@radix-ui/react-slider": {
       "version": "1.3.6",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
       "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
       "license": "MIT",
       "dependencies": {
@@ -2220,7 +2220,7 @@
     },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.4",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
       "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
       "license": "MIT",
       "dependencies": {
@@ -2238,7 +2238,7 @@
     },
     "node_modules/@radix-ui/react-switch": {
       "version": "1.2.6",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
       "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
       "license": "MIT",
       "dependencies": {
@@ -2267,7 +2267,7 @@
     },
     "node_modules/@radix-ui/react-tabs": {
       "version": "1.1.13",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
       "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
       "license": "MIT",
       "dependencies": {
@@ -2297,7 +2297,7 @@
     },
     "node_modules/@radix-ui/react-toast": {
       "version": "1.2.15",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
       "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
       "license": "MIT",
       "dependencies": {
@@ -2331,7 +2331,7 @@
     },
     "node_modules/@radix-ui/react-toggle": {
       "version": "1.1.10",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
       "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
       "license": "MIT",
       "dependencies": {
@@ -2356,7 +2356,7 @@
     },
     "node_modules/@radix-ui/react-toggle-group": {
       "version": "1.1.11",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
       "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
       "license": "MIT",
       "dependencies": {
@@ -2385,7 +2385,7 @@
     },
     "node_modules/@radix-ui/react-tooltip": {
       "version": "1.2.8",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
       "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
       "license": "MIT",
       "dependencies": {
@@ -2419,7 +2419,7 @@
     },
     "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
@@ -2437,7 +2437,7 @@
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
       "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
       "license": "MIT",
       "peerDependencies": {
@@ -2452,7 +2452,7 @@
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
       "version": "1.2.2",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
       "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
       "license": "MIT",
       "dependencies": {
@@ -2471,7 +2471,7 @@
     },
     "node_modules/@radix-ui/react-use-effect-event": {
       "version": "0.0.2",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
       "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
       "license": "MIT",
       "dependencies": {
@@ -2489,7 +2489,7 @@
     },
     "node_modules/@radix-ui/react-use-escape-keydown": {
       "version": "1.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
       "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
       "license": "MIT",
       "dependencies": {
@@ -2507,7 +2507,7 @@
     },
     "node_modules/@radix-ui/react-use-is-hydrated": {
       "version": "0.1.0",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
       "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
       "license": "MIT",
       "dependencies": {
@@ -2525,7 +2525,7 @@
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
       "version": "1.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -2540,7 +2540,7 @@
     },
     "node_modules/@radix-ui/react-use-previous": {
       "version": "1.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
       "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -2555,7 +2555,7 @@
     },
     "node_modules/@radix-ui/react-use-rect": {
       "version": "1.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
       "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
       "license": "MIT",
       "dependencies": {
@@ -2573,7 +2573,7 @@
     },
     "node_modules/@radix-ui/react-use-size": {
       "version": "1.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
       "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
       "license": "MIT",
       "dependencies": {
@@ -2591,7 +2591,7 @@
     },
     "node_modules/@radix-ui/react-visually-hidden": {
       "version": "1.2.3",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
       "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
       "license": "MIT",
       "dependencies": {
@@ -2614,13 +2614,13 @@
     },
     "node_modules/@radix-ui/rect": {
       "version": "1.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
     "node_modules/@react-spring/animated": {
       "version": "9.7.5",
-      "resolved": "https://npm.registries.huggingface.tech/@react-spring/animated/-/animated-9.7.5.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
       "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
       "license": "MIT",
       "dependencies": {
@@ -2633,7 +2633,7 @@
     },
     "node_modules/@react-spring/core": {
       "version": "9.7.5",
-      "resolved": "https://npm.registries.huggingface.tech/@react-spring/core/-/core-9.7.5.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
       "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
       "license": "MIT",
       "dependencies": {
@@ -2651,13 +2651,13 @@
     },
     "node_modules/@react-spring/rafz": {
       "version": "9.7.5",
-      "resolved": "https://npm.registries.huggingface.tech/@react-spring/rafz/-/rafz-9.7.5.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
       "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
       "license": "MIT"
     },
     "node_modules/@react-spring/shared": {
       "version": "9.7.5",
-      "resolved": "https://npm.registries.huggingface.tech/@react-spring/shared/-/shared-9.7.5.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
       "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
       "license": "MIT",
       "dependencies": {
@@ -2670,7 +2670,7 @@
     },
     "node_modules/@react-spring/three": {
       "version": "9.7.5",
-      "resolved": "https://npm.registries.huggingface.tech/@react-spring/three/-/three-9.7.5.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spring/three/-/three-9.7.5.tgz",
       "integrity": "sha512-RxIsCoQfUqOS3POmhVHa1wdWS0wyHAUway73uRLp3GAL5U2iYVNdnzQsep6M2NZ994BlW8TcKuMtQHUqOsy6WA==",
       "license": "MIT",
       "dependencies": {
@@ -2687,13 +2687,13 @@
     },
     "node_modules/@react-spring/types": {
       "version": "9.7.5",
-      "resolved": "https://npm.registries.huggingface.tech/@react-spring/types/-/types-9.7.5.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
       "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
       "license": "MIT"
     },
     "node_modules/@react-three/drei": {
       "version": "9.122.0",
-      "resolved": "https://npm.registries.huggingface.tech/@react-three/drei/-/drei-9.122.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.122.0.tgz",
       "integrity": "sha512-SEO/F/rBCTjlLez7WAlpys+iGe9hty4rNgjZvgkQeXFSiwqD4Hbk/wNHMAbdd8vprO2Aj81mihv4dF5bC7D0CA==",
       "license": "MIT",
       "dependencies": {
@@ -2734,7 +2734,7 @@
     },
     "node_modules/@react-three/fiber": {
       "version": "8.18.0",
-      "resolved": "https://npm.registries.huggingface.tech/@react-three/fiber/-/fiber-8.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
       "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
       "license": "MIT",
       "peer": true,
@@ -2784,7 +2784,7 @@
     },
     "node_modules/@react-three/fiber/node_modules/zustand": {
       "version": "3.7.2",
-      "resolved": "https://npm.registries.huggingface.tech/zustand/-/zustand-3.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
       "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
       "license": "MIT",
       "engines": {
@@ -2801,7 +2801,7 @@
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.3",
-      "resolved": "https://npm.registries.huggingface.tech/@remix-run/router/-/router-1.23.3.tgz",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
       "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
@@ -2810,7 +2810,7 @@
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
       "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
@@ -2827,7 +2827,7 @@
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
       "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
@@ -2844,7 +2844,7 @@
     },
     "node_modules/@rolldown/binding-darwin-x64": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
       "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
@@ -2861,7 +2861,7 @@
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
       "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
@@ -2878,7 +2878,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
       "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
@@ -2895,7 +2895,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
       "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
@@ -2912,7 +2912,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
       "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
@@ -2929,7 +2929,7 @@
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
       "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
@@ -2946,7 +2946,7 @@
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
       "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
@@ -2963,7 +2963,7 @@
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
       "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
@@ -2980,7 +2980,7 @@
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
       "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
@@ -2997,7 +2997,7 @@
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
       "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
@@ -3014,7 +3014,7 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
       "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
@@ -3033,7 +3033,7 @@
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
       "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
@@ -3050,7 +3050,7 @@
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
       "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
@@ -3067,14 +3067,14 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/core": {
       "version": "1.15.40",
-      "resolved": "https://npm.registries.huggingface.tech/@swc/core/-/core-1.15.40.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.40.tgz",
       "integrity": "sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==",
       "dev": true,
       "hasInstallScript": true,
@@ -3115,7 +3115,7 @@
     },
     "node_modules/@swc/core-darwin-arm64": {
       "version": "1.15.40",
-      "resolved": "https://npm.registries.huggingface.tech/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.40.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.40.tgz",
       "integrity": "sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ==",
       "cpu": [
         "arm64"
@@ -3132,7 +3132,7 @@
     },
     "node_modules/@swc/core-darwin-x64": {
       "version": "1.15.40",
-      "resolved": "https://npm.registries.huggingface.tech/@swc/core-darwin-x64/-/core-darwin-x64-1.15.40.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.40.tgz",
       "integrity": "sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA==",
       "cpu": [
         "x64"
@@ -3149,7 +3149,7 @@
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
       "version": "1.15.40",
-      "resolved": "https://npm.registries.huggingface.tech/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.40.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.40.tgz",
       "integrity": "sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA==",
       "cpu": [
         "arm"
@@ -3166,7 +3166,7 @@
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
       "version": "1.15.40",
-      "resolved": "https://npm.registries.huggingface.tech/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.40.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.40.tgz",
       "integrity": "sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ==",
       "cpu": [
         "arm64"
@@ -3183,7 +3183,7 @@
     },
     "node_modules/@swc/core-linux-arm64-musl": {
       "version": "1.15.40",
-      "resolved": "https://npm.registries.huggingface.tech/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.40.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.40.tgz",
       "integrity": "sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==",
       "cpu": [
         "arm64"
@@ -3200,7 +3200,7 @@
     },
     "node_modules/@swc/core-linux-ppc64-gnu": {
       "version": "1.15.40",
-      "resolved": "https://npm.registries.huggingface.tech/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.40.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.40.tgz",
       "integrity": "sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==",
       "cpu": [
         "ppc64"
@@ -3217,7 +3217,7 @@
     },
     "node_modules/@swc/core-linux-s390x-gnu": {
       "version": "1.15.40",
-      "resolved": "https://npm.registries.huggingface.tech/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.40.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.40.tgz",
       "integrity": "sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==",
       "cpu": [
         "s390x"
@@ -3234,7 +3234,7 @@
     },
     "node_modules/@swc/core-linux-x64-gnu": {
       "version": "1.15.40",
-      "resolved": "https://npm.registries.huggingface.tech/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.40.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.40.tgz",
       "integrity": "sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==",
       "cpu": [
         "x64"
@@ -3251,7 +3251,7 @@
     },
     "node_modules/@swc/core-linux-x64-musl": {
       "version": "1.15.40",
-      "resolved": "https://npm.registries.huggingface.tech/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.40.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.40.tgz",
       "integrity": "sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==",
       "cpu": [
         "x64"
@@ -3268,7 +3268,7 @@
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
       "version": "1.15.40",
-      "resolved": "https://npm.registries.huggingface.tech/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.40.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.40.tgz",
       "integrity": "sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==",
       "cpu": [
         "arm64"
@@ -3285,7 +3285,7 @@
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
       "version": "1.15.40",
-      "resolved": "https://npm.registries.huggingface.tech/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.40.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.40.tgz",
       "integrity": "sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw==",
       "cpu": [
         "ia32"
@@ -3302,7 +3302,7 @@
     },
     "node_modules/@swc/core-win32-x64-msvc": {
       "version": "1.15.40",
-      "resolved": "https://npm.registries.huggingface.tech/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.40.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.40.tgz",
       "integrity": "sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w==",
       "cpu": [
         "x64"
@@ -3319,14 +3319,14 @@
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
-      "resolved": "https://npm.registries.huggingface.tech/@swc/counter/-/counter-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.26",
-      "resolved": "https://npm.registries.huggingface.tech/@swc/types/-/types-0.1.26.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
       "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -3336,7 +3336,7 @@
     },
     "node_modules/@tailwindcss/typography": {
       "version": "0.5.19",
-      "resolved": "https://npm.registries.huggingface.tech/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
       "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
       "dev": true,
       "license": "MIT",
@@ -3349,7 +3349,7 @@
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.101.0",
-      "resolved": "https://npm.registries.huggingface.tech/@tanstack/query-core/-/query-core-5.101.0.tgz",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
       "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
       "license": "MIT",
       "funding": {
@@ -3359,7 +3359,7 @@
     },
     "node_modules/@tanstack/react-query": {
       "version": "5.101.0",
-      "resolved": "https://npm.registries.huggingface.tech/@tanstack/react-query/-/react-query-5.101.0.tgz",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
       "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
       "license": "MIT",
       "dependencies": {
@@ -3375,13 +3375,13 @@
     },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
-      "resolved": "https://npm.registries.huggingface.tech/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
       "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
-      "resolved": "https://npm.registries.huggingface.tech/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
@@ -3392,25 +3392,25 @@
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
-      "resolved": "https://npm.registries.huggingface.tech/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
       "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
-      "resolved": "https://npm.registries.huggingface.tech/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
-      "resolved": "https://npm.registries.huggingface.tech/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
-      "resolved": "https://npm.registries.huggingface.tech/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
       "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
       "license": "MIT",
       "dependencies": {
@@ -3419,13 +3419,13 @@
     },
     "node_modules/@types/d3-path": {
       "version": "3.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
       "license": "MIT"
     },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
-      "resolved": "https://npm.registries.huggingface.tech/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
       "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
       "license": "MIT",
       "dependencies": {
@@ -3434,7 +3434,7 @@
     },
     "node_modules/@types/d3-shape": {
       "version": "3.1.8",
-      "resolved": "https://npm.registries.huggingface.tech/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
       "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
       "license": "MIT",
       "dependencies": {
@@ -3443,39 +3443,39 @@
     },
     "node_modules/@types/d3-time": {
       "version": "3.0.4",
-      "resolved": "https://npm.registries.huggingface.tech/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
       "license": "MIT"
     },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
-      "resolved": "https://npm.registries.huggingface.tech/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/draco3d": {
       "version": "1.4.10",
-      "resolved": "https://npm.registries.huggingface.tech/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
       "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
-      "resolved": "https://npm.registries.huggingface.tech/@types/estree/-/estree-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://npm.registries.huggingface.tech/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.19.19",
-      "resolved": "https://npm.registries.huggingface.tech/@types/node/-/node-22.19.19.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
       "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
@@ -3486,19 +3486,19 @@
     },
     "node_modules/@types/offscreencanvas": {
       "version": "2019.7.3",
-      "resolved": "https://npm.registries.huggingface.tech/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
       "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "resolved": "https://npm.registries.huggingface.tech/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.30",
-      "resolved": "https://npm.registries.huggingface.tech/@types/react/-/react-18.3.30.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.30.tgz",
       "integrity": "sha512-3ek6mwJL5/VBewBcY4S66cqlCtK3qi4WIq37Z0m/NHw1hjhI7274Mx1qz/+ggSzyBCOEf7eHjBN6INjPAWYfYw==",
       "license": "MIT",
       "peer": true,
@@ -3509,7 +3509,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "18.3.7",
-      "resolved": "https://npm.registries.huggingface.tech/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
@@ -3520,7 +3520,7 @@
     },
     "node_modules/@types/react-reconciler": {
       "version": "0.26.7",
-      "resolved": "https://npm.registries.huggingface.tech/@types/react-reconciler/-/react-reconciler-0.26.7.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.7.tgz",
       "integrity": "sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==",
       "license": "MIT",
       "dependencies": {
@@ -3529,13 +3529,13 @@
     },
     "node_modules/@types/stats.js": {
       "version": "0.17.4",
-      "resolved": "https://npm.registries.huggingface.tech/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
       "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
       "license": "MIT"
     },
     "node_modules/@types/three": {
       "version": "0.184.1",
-      "resolved": "https://npm.registries.huggingface.tech/@types/three/-/three-0.184.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.1.tgz",
       "integrity": "sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==",
       "license": "MIT",
       "peer": true,
@@ -3550,13 +3550,13 @@
     },
     "node_modules/@types/webxr": {
       "version": "0.5.24",
-      "resolved": "https://npm.registries.huggingface.tech/@types/webxr/-/webxr-0.5.24.tgz",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.60.1",
-      "resolved": "https://npm.registries.huggingface.tech/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
       "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
       "dev": true,
       "license": "MIT",
@@ -3585,7 +3585,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
       "version": "7.0.5",
-      "resolved": "https://npm.registries.huggingface.tech/ignore/-/ignore-7.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
@@ -3595,7 +3595,7 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.60.1",
-      "resolved": "https://npm.registries.huggingface.tech/@typescript-eslint/parser/-/parser-8.60.1.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
@@ -3621,7 +3621,7 @@
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.60.1",
-      "resolved": "https://npm.registries.huggingface.tech/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
       "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
       "dev": true,
       "license": "MIT",
@@ -3643,7 +3643,7 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.60.1",
-      "resolved": "https://npm.registries.huggingface.tech/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
       "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
       "dev": true,
       "license": "MIT",
@@ -3661,7 +3661,7 @@
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
       "version": "8.60.1",
-      "resolved": "https://npm.registries.huggingface.tech/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
       "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
       "dev": true,
       "license": "MIT",
@@ -3678,7 +3678,7 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "8.60.1",
-      "resolved": "https://npm.registries.huggingface.tech/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
       "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
       "dev": true,
       "license": "MIT",
@@ -3703,7 +3703,7 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.60.1",
-      "resolved": "https://npm.registries.huggingface.tech/@typescript-eslint/types/-/types-8.60.1.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
       "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
       "dev": true,
       "license": "MIT",
@@ -3717,7 +3717,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.60.1",
-      "resolved": "https://npm.registries.huggingface.tech/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
       "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
       "dev": true,
       "license": "MIT",
@@ -3745,7 +3745,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://npm.registries.huggingface.tech/balanced-match/-/balanced-match-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
@@ -3755,7 +3755,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
       "version": "5.0.6",
-      "resolved": "https://npm.registries.huggingface.tech/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
       "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
@@ -3768,7 +3768,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "10.2.5",
-      "resolved": "https://npm.registries.huggingface.tech/minimatch/-/minimatch-10.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3784,7 +3784,7 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.60.1",
-      "resolved": "https://npm.registries.huggingface.tech/@typescript-eslint/utils/-/utils-8.60.1.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
       "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
       "dev": true,
       "license": "MIT",
@@ -3808,7 +3808,7 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.60.1",
-      "resolved": "https://npm.registries.huggingface.tech/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
       "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
       "dev": true,
       "license": "MIT",
@@ -3826,7 +3826,7 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -3839,13 +3839,13 @@
     },
     "node_modules/@use-gesture/core": {
       "version": "10.3.1",
-      "resolved": "https://npm.registries.huggingface.tech/@use-gesture/core/-/core-10.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
       "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
       "license": "MIT"
     },
     "node_modules/@use-gesture/react": {
       "version": "10.3.1",
-      "resolved": "https://npm.registries.huggingface.tech/@use-gesture/react/-/react-10.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
       "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
       "license": "MIT",
       "dependencies": {
@@ -3857,7 +3857,7 @@
     },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "4.3.1",
-      "resolved": "https://npm.registries.huggingface.tech/@vitejs/plugin-react-swc/-/plugin-react-swc-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-4.3.1.tgz",
       "integrity": "sha512-PaeokKjAGraNN+s5SIApgsktnJprIyt3zgEIu7awnEdfn29QiB2crTcCzyi2XGpX9rUnTc0cKU07Wm0N0g7H2w==",
       "dev": true,
       "license": "MIT",
@@ -3874,7 +3874,7 @@
     },
     "node_modules/acorn": {
       "version": "8.16.0",
-      "resolved": "https://npm.registries.huggingface.tech/acorn/-/acorn-8.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
@@ -3888,7 +3888,7 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://npm.registries.huggingface.tech/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
@@ -3898,7 +3898,7 @@
     },
     "node_modules/ajv": {
       "version": "6.15.0",
-      "resolved": "https://npm.registries.huggingface.tech/ajv/-/ajv-6.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
@@ -3915,7 +3915,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://npm.registries.huggingface.tech/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
@@ -3931,13 +3931,13 @@
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
-      "resolved": "https://npm.registries.huggingface.tech/any-promise/-/any-promise-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "resolved": "https://npm.registries.huggingface.tech/anymatch/-/anymatch-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "license": "ISC",
       "dependencies": {
@@ -3950,20 +3950,20 @@
     },
     "node_modules/arg": {
       "version": "5.0.2",
-      "resolved": "https://npm.registries.huggingface.tech/arg/-/arg-5.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/argparse/-/argparse-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
-      "resolved": "https://npm.registries.huggingface.tech/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
       "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
       "license": "MIT",
       "dependencies": {
@@ -3975,7 +3975,7 @@
     },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
-      "resolved": "https://npm.registries.huggingface.tech/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
       "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
       "dev": true,
       "funding": [
@@ -4012,14 +4012,14 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://npm.registries.huggingface.tech/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "resolved": "https://npm.registries.huggingface.tech/base64-js/-/base64-js-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "funding": [
         {
@@ -4039,7 +4039,7 @@
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.33",
-      "resolved": "https://npm.registries.huggingface.tech/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
       "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -4052,7 +4052,7 @@
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/bidi-js/-/bidi-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
       "license": "MIT",
       "dependencies": {
@@ -4061,7 +4061,7 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
-      "resolved": "https://npm.registries.huggingface.tech/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "license": "MIT",
       "engines": {
@@ -4073,7 +4073,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.15",
-      "resolved": "https://npm.registries.huggingface.tech/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
@@ -4084,7 +4084,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/braces/-/braces-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "license": "MIT",
       "dependencies": {
@@ -4096,7 +4096,7 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.2",
-      "resolved": "https://npm.registries.huggingface.tech/browserslist/-/browserslist-4.28.2.tgz",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
@@ -4131,7 +4131,7 @@
     },
     "node_modules/buffer": {
       "version": "6.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/buffer/-/buffer-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
@@ -4155,7 +4155,7 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "https://npm.registries.huggingface.tech/callsites/-/callsites-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
@@ -4165,7 +4165,7 @@
     },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
       "license": "MIT",
       "engines": {
@@ -4174,7 +4174,7 @@
     },
     "node_modules/camera-controls": {
       "version": "2.10.1",
-      "resolved": "https://npm.registries.huggingface.tech/camera-controls/-/camera-controls-2.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-2.10.1.tgz",
       "integrity": "sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w==",
       "license": "MIT",
       "peerDependencies": {
@@ -4183,7 +4183,7 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001793",
-      "resolved": "https://npm.registries.huggingface.tech/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
       "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
@@ -4204,7 +4204,7 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://npm.registries.huggingface.tech/chalk/-/chalk-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
@@ -4221,7 +4221,7 @@
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
-      "resolved": "https://npm.registries.huggingface.tech/chokidar/-/chokidar-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "license": "MIT",
       "dependencies": {
@@ -4245,7 +4245,7 @@
     },
     "node_modules/chokidar/node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://npm.registries.huggingface.tech/glob-parent/-/glob-parent-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "license": "ISC",
       "dependencies": {
@@ -4257,7 +4257,7 @@
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
-      "resolved": "https://npm.registries.huggingface.tech/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
       "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -4269,7 +4269,7 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/clsx/-/clsx-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
       "engines": {
@@ -4278,7 +4278,7 @@
     },
     "node_modules/cmdk": {
       "version": "1.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/cmdk/-/cmdk-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
       "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
       "license": "MIT",
       "dependencies": {
@@ -4294,7 +4294,7 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
@@ -4307,14 +4307,14 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://npm.registries.huggingface.tech/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
       "version": "4.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/commander/-/commander-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "license": "MIT",
       "engines": {
@@ -4323,20 +4323,20 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/core-util-is/-/core-util-is-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/cross-env/-/cross-env-7.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
       "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
       "license": "MIT",
       "dependencies": {
@@ -4354,7 +4354,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://npm.registries.huggingface.tech/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
@@ -4368,7 +4368,7 @@
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/cssesc/-/cssesc-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "license": "MIT",
       "bin": {
@@ -4380,13 +4380,13 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://npm.registries.huggingface.tech/csstype/-/csstype-3.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
-      "resolved": "https://npm.registries.huggingface.tech/d3-array/-/d3-array-3.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
       "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
       "license": "ISC",
       "dependencies": {
@@ -4398,7 +4398,7 @@
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
-      "resolved": "https://npm.registries.huggingface.tech/d3-color/-/d3-color-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "license": "ISC",
       "engines": {
@@ -4407,7 +4407,7 @@
     },
     "node_modules/d3-ease": {
       "version": "3.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/d3-ease/-/d3-ease-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
       "engines": {
@@ -4416,7 +4416,7 @@
     },
     "node_modules/d3-format": {
       "version": "3.1.2",
-      "resolved": "https://npm.registries.huggingface.tech/d3-format/-/d3-format-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
       "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
       "license": "ISC",
       "engines": {
@@ -4425,7 +4425,7 @@
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "license": "ISC",
       "dependencies": {
@@ -4437,7 +4437,7 @@
     },
     "node_modules/d3-path": {
       "version": "3.1.0",
-      "resolved": "https://npm.registries.huggingface.tech/d3-path/-/d3-path-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
       "license": "ISC",
       "engines": {
@@ -4446,7 +4446,7 @@
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",
-      "resolved": "https://npm.registries.huggingface.tech/d3-scale/-/d3-scale-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
       "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
       "license": "ISC",
       "dependencies": {
@@ -4462,7 +4462,7 @@
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
-      "resolved": "https://npm.registries.huggingface.tech/d3-shape/-/d3-shape-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
       "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
       "license": "ISC",
       "dependencies": {
@@ -4474,7 +4474,7 @@
     },
     "node_modules/d3-time": {
       "version": "3.1.0",
-      "resolved": "https://npm.registries.huggingface.tech/d3-time/-/d3-time-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
       "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
       "license": "ISC",
       "dependencies": {
@@ -4486,7 +4486,7 @@
     },
     "node_modules/d3-time-format": {
       "version": "4.1.0",
-      "resolved": "https://npm.registries.huggingface.tech/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
       "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
       "license": "ISC",
       "dependencies": {
@@ -4498,7 +4498,7 @@
     },
     "node_modules/d3-timer": {
       "version": "3.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/d3-timer/-/d3-timer-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "license": "ISC",
       "engines": {
@@ -4507,7 +4507,7 @@
     },
     "node_modules/date-fns": {
       "version": "3.6.0",
-      "resolved": "https://npm.registries.huggingface.tech/date-fns/-/date-fns-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
       "peer": true,
@@ -4518,7 +4518,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://npm.registries.huggingface.tech/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -4536,20 +4536,20 @@
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
-      "resolved": "https://npm.registries.huggingface.tech/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://npm.registries.huggingface.tech/deep-is/-/deep-is-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-gpu": {
       "version": "5.0.70",
-      "resolved": "https://npm.registries.huggingface.tech/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
       "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
       "license": "MIT",
       "dependencies": {
@@ -4558,7 +4558,7 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://npm.registries.huggingface.tech/detect-libc/-/detect-libc-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -4568,25 +4568,25 @@
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
-      "resolved": "https://npm.registries.huggingface.tech/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
-      "resolved": "https://npm.registries.huggingface.tech/didyoumean/-/didyoumean-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
-      "resolved": "https://npm.registries.huggingface.tech/dlv/-/dlv-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
-      "resolved": "https://npm.registries.huggingface.tech/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
       "license": "MIT",
       "dependencies": {
@@ -4596,27 +4596,27 @@
     },
     "node_modules/draco3d": {
       "version": "1.5.7",
-      "resolved": "https://npm.registries.huggingface.tech/draco3d/-/draco3d-1.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
       "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
       "license": "Apache-2.0"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.368",
-      "resolved": "https://npm.registries.huggingface.tech/electron-to-chromium/-/electron-to-chromium-1.5.368.tgz",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.368.tgz",
       "integrity": "sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/embla-carousel": {
       "version": "8.6.0",
-      "resolved": "https://npm.registries.huggingface.tech/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
-      "resolved": "https://npm.registries.huggingface.tech/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
       "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
       "license": "MIT",
       "dependencies": {
@@ -4629,7 +4629,7 @@
     },
     "node_modules/embla-carousel-reactive-utils": {
       "version": "8.6.0",
-      "resolved": "https://npm.registries.huggingface.tech/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
       "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
       "license": "MIT",
       "peerDependencies": {
@@ -4638,7 +4638,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://npm.registries.huggingface.tech/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
       "engines": {
@@ -4647,7 +4647,7 @@
     },
     "node_modules/esbuild": {
       "version": "0.28.0",
-      "resolved": "https://npm.registries.huggingface.tech/esbuild/-/esbuild-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "dev": true,
       "hasInstallScript": true,
@@ -4691,7 +4691,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://npm.registries.huggingface.tech/escalade/-/escalade-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
@@ -4701,7 +4701,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
@@ -4714,7 +4714,7 @@
     },
     "node_modules/eslint": {
       "version": "9.39.4",
-      "resolved": "https://npm.registries.huggingface.tech/eslint/-/eslint-9.39.4.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
@@ -4775,7 +4775,7 @@
     },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "5.2.0",
-      "resolved": "https://npm.registries.huggingface.tech/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
       "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
       "dev": true,
       "license": "MIT",
@@ -4788,7 +4788,7 @@
     },
     "node_modules/eslint-plugin-react-refresh": {
       "version": "0.4.26",
-      "resolved": "https://npm.registries.huggingface.tech/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
       "integrity": "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==",
       "dev": true,
       "license": "MIT",
@@ -4798,7 +4798,7 @@
     },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
-      "resolved": "https://npm.registries.huggingface.tech/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
       "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4815,7 +4815,7 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
-      "resolved": "https://npm.registries.huggingface.tech/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -4828,7 +4828,7 @@
     },
     "node_modules/espree": {
       "version": "10.4.0",
-      "resolved": "https://npm.registries.huggingface.tech/espree/-/espree-10.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
       "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4846,7 +4846,7 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
-      "resolved": "https://npm.registries.huggingface.tech/esquery/-/esquery-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -4859,7 +4859,7 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://npm.registries.huggingface.tech/esrecurse/-/esrecurse-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4872,7 +4872,7 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://npm.registries.huggingface.tech/estraverse/-/estraverse-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4882,7 +4882,7 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/esutils/-/esutils-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4892,20 +4892,20 @@
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
-      "resolved": "https://npm.registries.huggingface.tech/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://npm.registries.huggingface.tech/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-equals": {
       "version": "5.4.0",
-      "resolved": "https://npm.registries.huggingface.tech/fast-equals/-/fast-equals-5.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
       "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
       "license": "MIT",
       "engines": {
@@ -4914,7 +4914,7 @@
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
-      "resolved": "https://npm.registries.huggingface.tech/fast-glob/-/fast-glob-3.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "license": "MIT",
       "dependencies": {
@@ -4930,7 +4930,7 @@
     },
     "node_modules/fast-glob/node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://npm.registries.huggingface.tech/glob-parent/-/glob-parent-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "license": "ISC",
       "dependencies": {
@@ -4942,21 +4942,21 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://npm.registries.huggingface.tech/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://npm.registries.huggingface.tech/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
-      "resolved": "https://npm.registries.huggingface.tech/fastq/-/fastq-1.20.1.tgz",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "license": "ISC",
       "dependencies": {
@@ -4965,13 +4965,13 @@
     },
     "node_modules/fflate": {
       "version": "0.8.3",
-      "resolved": "https://npm.registries.huggingface.tech/fflate/-/fflate-0.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
       "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
@@ -4984,7 +4984,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/fill-range/-/fill-range-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "license": "MIT",
       "dependencies": {
@@ -4996,7 +4996,7 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/find-up/-/find-up-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
@@ -5013,7 +5013,7 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/flat-cache/-/flat-cache-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
@@ -5027,14 +5027,14 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
-      "resolved": "https://npm.registries.huggingface.tech/flatted/-/flatted-3.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/fraction.js": {
       "version": "5.3.4",
-      "resolved": "https://npm.registries.huggingface.tech/fraction.js/-/fraction.js-5.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
       "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
       "dev": true,
       "license": "MIT",
@@ -5048,7 +5048,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://npm.registries.huggingface.tech/fsevents/-/fsevents-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "hasInstallScript": true,
       "license": "MIT",
@@ -5062,7 +5062,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://npm.registries.huggingface.tech/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
       "funding": {
@@ -5071,7 +5071,7 @@
     },
     "node_modules/get-nonce": {
       "version": "1.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/get-nonce/-/get-nonce-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
       "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
       "license": "MIT",
       "engines": {
@@ -5080,7 +5080,7 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://npm.registries.huggingface.tech/glob-parent/-/glob-parent-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "license": "ISC",
       "dependencies": {
@@ -5092,7 +5092,7 @@
     },
     "node_modules/globals": {
       "version": "15.15.0",
-      "resolved": "https://npm.registries.huggingface.tech/globals/-/globals-15.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
       "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
       "dev": true,
       "license": "MIT",
@@ -5105,13 +5105,13 @@
     },
     "node_modules/glsl-noise": {
       "version": "0.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
       "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
       "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/has-flag/-/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
@@ -5121,7 +5121,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.4",
-      "resolved": "https://npm.registries.huggingface.tech/hasown/-/hasown-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
@@ -5133,13 +5133,13 @@
     },
     "node_modules/hls.js": {
       "version": "1.6.16",
-      "resolved": "https://npm.registries.huggingface.tech/hls.js/-/hls.js-1.6.16.tgz",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
       "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
       "license": "Apache-2.0"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "resolved": "https://npm.registries.huggingface.tech/ieee754/-/ieee754-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "funding": [
         {
@@ -5159,7 +5159,7 @@
     },
     "node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://npm.registries.huggingface.tech/ignore/-/ignore-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
@@ -5169,13 +5169,13 @@
     },
     "node_modules/immediate": {
       "version": "3.0.6",
-      "resolved": "https://npm.registries.huggingface.tech/immediate/-/immediate-3.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
-      "resolved": "https://npm.registries.huggingface.tech/import-fresh/-/import-fresh-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
@@ -5192,7 +5192,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://npm.registries.huggingface.tech/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
@@ -5202,13 +5202,13 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://npm.registries.huggingface.tech/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
     "node_modules/input-otp": {
       "version": "1.4.2",
-      "resolved": "https://npm.registries.huggingface.tech/input-otp/-/input-otp-1.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
       "integrity": "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==",
       "license": "MIT",
       "peerDependencies": {
@@ -5218,7 +5218,7 @@
     },
     "node_modules/internmap": {
       "version": "2.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/internmap/-/internmap-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
       "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
       "license": "ISC",
       "engines": {
@@ -5227,7 +5227,7 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "resolved": "https://npm.registries.huggingface.tech/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "license": "MIT",
       "dependencies": {
@@ -5239,7 +5239,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.2",
-      "resolved": "https://npm.registries.huggingface.tech/is-core-module/-/is-core-module-2.16.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
       "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "license": "MIT",
       "dependencies": {
@@ -5254,7 +5254,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "license": "MIT",
       "engines": {
@@ -5263,7 +5263,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/is-glob/-/is-glob-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "license": "MIT",
       "dependencies": {
@@ -5275,7 +5275,7 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/is-number/-/is-number-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "license": "MIT",
       "engines": {
@@ -5284,25 +5284,25 @@
     },
     "node_modules/is-promise": {
       "version": "2.2.2",
-      "resolved": "https://npm.registries.huggingface.tech/is-promise/-/is-promise-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
     "node_modules/its-fine": {
       "version": "1.2.5",
-      "resolved": "https://npm.registries.huggingface.tech/its-fine/-/its-fine-1.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
       "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
       "license": "MIT",
       "dependencies": {
@@ -5314,7 +5314,7 @@
     },
     "node_modules/its-fine/node_modules/@types/react-reconciler": {
       "version": "0.28.9",
-      "resolved": "https://npm.registries.huggingface.tech/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
       "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
       "license": "MIT",
       "peerDependencies": {
@@ -5323,7 +5323,7 @@
     },
     "node_modules/jiti": {
       "version": "1.21.7",
-      "resolved": "https://npm.registries.huggingface.tech/jiti/-/jiti-1.21.7.tgz",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
       "peer": true,
@@ -5333,13 +5333,13 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.2.0",
-      "resolved": "https://npm.registries.huggingface.tech/js-yaml/-/js-yaml-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
       "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
       "funding": [
@@ -5362,28 +5362,28 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/json-buffer/-/json-buffer-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://npm.registries.huggingface.tech/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/jszip": {
       "version": "3.10.1",
-      "resolved": "https://npm.registries.huggingface.tech/jszip/-/jszip-3.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
       "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
@@ -5395,7 +5395,7 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://npm.registries.huggingface.tech/keyv/-/keyv-4.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
@@ -5405,7 +5405,7 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://npm.registries.huggingface.tech/levn/-/levn-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
@@ -5419,7 +5419,7 @@
     },
     "node_modules/lie": {
       "version": "3.3.0",
-      "resolved": "https://npm.registries.huggingface.tech/lie/-/lie-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
       "license": "MIT",
       "dependencies": {
@@ -5428,7 +5428,7 @@
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://npm.registries.huggingface.tech/lightningcss/-/lightningcss-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
@@ -5458,7 +5458,7 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
-      "resolved": "https://npm.registries.huggingface.tech/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
@@ -5479,7 +5479,7 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://npm.registries.huggingface.tech/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
@@ -5500,7 +5500,7 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
-      "resolved": "https://npm.registries.huggingface.tech/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
@@ -5521,7 +5521,7 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.32.0",
-      "resolved": "https://npm.registries.huggingface.tech/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
@@ -5542,7 +5542,7 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
-      "resolved": "https://npm.registries.huggingface.tech/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
@@ -5563,7 +5563,7 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://npm.registries.huggingface.tech/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
@@ -5584,7 +5584,7 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
-      "resolved": "https://npm.registries.huggingface.tech/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
@@ -5605,7 +5605,7 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://npm.registries.huggingface.tech/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
@@ -5626,7 +5626,7 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
-      "resolved": "https://npm.registries.huggingface.tech/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
@@ -5647,7 +5647,7 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://npm.registries.huggingface.tech/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
@@ -5668,7 +5668,7 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://npm.registries.huggingface.tech/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
@@ -5689,7 +5689,7 @@
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
-      "resolved": "https://npm.registries.huggingface.tech/lilconfig/-/lilconfig-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
       "license": "MIT",
       "engines": {
@@ -5701,13 +5701,13 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://npm.registries.huggingface.tech/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/locate-path/-/locate-path-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
@@ -5723,20 +5723,20 @@
     },
     "node_modules/lodash": {
       "version": "4.18.1",
-      "resolved": "https://npm.registries.huggingface.tech/lodash/-/lodash-4.18.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://npm.registries.huggingface.tech/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://npm.registries.huggingface.tech/loose-envify/-/loose-envify-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "license": "MIT",
       "dependencies": {
@@ -5748,7 +5748,7 @@
     },
     "node_modules/lovable-tagger": {
       "version": "1.3.0",
-      "resolved": "https://npm.registries.huggingface.tech/lovable-tagger/-/lovable-tagger-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/lovable-tagger/-/lovable-tagger-1.3.0.tgz",
       "integrity": "sha512-X2TX4g+/8VUFIBboGBjgXIdjEhR1ojtz9W65MO3g069DXTX5PPFZ4ihQzzociTL9HCwCC8SleVGT/wcfURhMXA==",
       "dev": true,
       "license": "MIT",
@@ -5762,7 +5762,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
       "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
@@ -5779,7 +5779,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/android-arm": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
       "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
@@ -5796,7 +5796,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/android-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
       "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
@@ -5813,7 +5813,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/android-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
       "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
@@ -5830,7 +5830,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
       "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
@@ -5847,7 +5847,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/darwin-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
       "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
@@ -5864,7 +5864,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/freebsd-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
       "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
@@ -5881,7 +5881,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/freebsd-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
       "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
@@ -5898,7 +5898,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/linux-arm": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
       "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
@@ -5915,7 +5915,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/linux-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
       "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
@@ -5932,7 +5932,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/linux-ia32": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
       "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
@@ -5949,7 +5949,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/linux-loong64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
       "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
@@ -5966,7 +5966,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/linux-mips64el": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
       "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
@@ -5983,7 +5983,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/linux-ppc64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
       "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
@@ -6000,7 +6000,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/linux-riscv64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
       "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
@@ -6017,7 +6017,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/linux-s390x": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
       "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
@@ -6034,7 +6034,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/linux-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
       "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
@@ -6051,7 +6051,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/netbsd-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
       "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
       "cpu": [
         "arm64"
@@ -6068,7 +6068,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/netbsd-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
       "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
@@ -6085,7 +6085,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/openbsd-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
       "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
       "cpu": [
         "arm64"
@@ -6102,7 +6102,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/openbsd-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
       "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
@@ -6119,7 +6119,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/openharmony-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
       "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
       "cpu": [
         "arm64"
@@ -6136,7 +6136,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/sunos-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
       "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
@@ -6153,7 +6153,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/win32-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
       "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
@@ -6170,7 +6170,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/win32-ia32": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
       "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
@@ -6187,7 +6187,7 @@
     },
     "node_modules/lovable-tagger/node_modules/@esbuild/win32-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
       "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
@@ -6204,7 +6204,7 @@
     },
     "node_modules/lovable-tagger/node_modules/esbuild": {
       "version": "0.25.12",
-      "resolved": "https://npm.registries.huggingface.tech/esbuild/-/esbuild-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
@@ -6246,7 +6246,7 @@
     },
     "node_modules/lucide-react": {
       "version": "0.462.0",
-      "resolved": "https://npm.registries.huggingface.tech/lucide-react/-/lucide-react-0.462.0.tgz",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.462.0.tgz",
       "integrity": "sha512-NTL7EbAao9IFtuSivSZgrAh4fZd09Lr+6MTkqIxuHaH2nnYiYIzXPo06cOxHg9wKLdj6LL8TByG4qpePqwgx/g==",
       "license": "ISC",
       "peerDependencies": {
@@ -6255,7 +6255,7 @@
     },
     "node_modules/maath": {
       "version": "0.10.8",
-      "resolved": "https://npm.registries.huggingface.tech/maath/-/maath-0.10.8.tgz",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
       "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
       "license": "MIT",
       "peerDependencies": {
@@ -6265,7 +6265,7 @@
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "resolved": "https://npm.registries.huggingface.tech/merge2/-/merge2-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "license": "MIT",
       "engines": {
@@ -6274,7 +6274,7 @@
     },
     "node_modules/meshline": {
       "version": "3.3.1",
-      "resolved": "https://npm.registries.huggingface.tech/meshline/-/meshline-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
       "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -6283,13 +6283,13 @@
     },
     "node_modules/meshoptimizer": {
       "version": "1.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
       "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
       "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "https://npm.registries.huggingface.tech/micromatch/-/micromatch-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "license": "MIT",
       "dependencies": {
@@ -6302,7 +6302,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://npm.registries.huggingface.tech/minimatch/-/minimatch-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
@@ -6315,14 +6315,14 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://npm.registries.huggingface.tech/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
       "version": "2.7.0",
-      "resolved": "https://npm.registries.huggingface.tech/mz/-/mz-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "license": "MIT",
       "dependencies": {
@@ -6333,7 +6333,7 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
-      "resolved": "https://npm.registries.huggingface.tech/nanoid/-/nanoid-3.3.12.tgz",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
       "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
@@ -6351,14 +6351,14 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://npm.registries.huggingface.tech/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/next-themes": {
       "version": "0.3.0",
-      "resolved": "https://npm.registries.huggingface.tech/next-themes/-/next-themes-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.3.0.tgz",
       "integrity": "sha512-/QHIrsYpd6Kfk7xakK4svpDI5mmXP0gfvCoJdGpZQ2TOrQZmsW0QxjaiLn8wbIKjtm4BTSqLoix4lxYYOnLJ/w==",
       "license": "MIT",
       "peerDependencies": {
@@ -6368,7 +6368,7 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.47",
-      "resolved": "https://npm.registries.huggingface.tech/node-releases/-/node-releases-2.0.47.tgz",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
       "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
       "license": "MIT",
@@ -6378,7 +6378,7 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/normalize-path/-/normalize-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "license": "MIT",
       "engines": {
@@ -6387,7 +6387,7 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
@@ -6396,7 +6396,7 @@
     },
     "node_modules/object-hash": {
       "version": "3.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/object-hash/-/object-hash-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "license": "MIT",
       "engines": {
@@ -6405,7 +6405,7 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "resolved": "https://npm.registries.huggingface.tech/optionator/-/optionator-0.9.4.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
@@ -6423,7 +6423,7 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://npm.registries.huggingface.tech/p-limit/-/p-limit-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
@@ -6439,7 +6439,7 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/p-locate/-/p-locate-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
@@ -6455,13 +6455,13 @@
     },
     "node_modules/pako": {
       "version": "1.0.11",
-      "resolved": "https://npm.registries.huggingface.tech/pako/-/pako-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/parent-module/-/parent-module-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
@@ -6474,7 +6474,7 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/path-exists/-/path-exists-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
@@ -6484,7 +6484,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
       "engines": {
@@ -6493,19 +6493,19 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://npm.registries.huggingface.tech/path-parse/-/path-parse-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://npm.registries.huggingface.tech/picomatch/-/picomatch-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
@@ -6517,7 +6517,7 @@
     },
     "node_modules/pify": {
       "version": "2.3.0",
-      "resolved": "https://npm.registries.huggingface.tech/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "license": "MIT",
       "engines": {
@@ -6526,7 +6526,7 @@
     },
     "node_modules/pirates": {
       "version": "4.0.7",
-      "resolved": "https://npm.registries.huggingface.tech/pirates/-/pirates-4.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "license": "MIT",
       "engines": {
@@ -6535,7 +6535,7 @@
     },
     "node_modules/postcss": {
       "version": "8.5.15",
-      "resolved": "https://npm.registries.huggingface.tech/postcss/-/postcss-8.5.15.tgz",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
@@ -6564,7 +6564,7 @@
     },
     "node_modules/postcss-import": {
       "version": "15.1.0",
-      "resolved": "https://npm.registries.huggingface.tech/postcss-import/-/postcss-import-15.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
       "license": "MIT",
       "dependencies": {
@@ -6581,7 +6581,7 @@
     },
     "node_modules/postcss-js": {
       "version": "4.1.0",
-      "resolved": "https://npm.registries.huggingface.tech/postcss-js/-/postcss-js-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
       "funding": [
         {
@@ -6606,7 +6606,7 @@
     },
     "node_modules/postcss-load-config": {
       "version": "6.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
       "funding": [
         {
@@ -6648,7 +6648,7 @@
     },
     "node_modules/postcss-nested": {
       "version": "6.2.0",
-      "resolved": "https://npm.registries.huggingface.tech/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
       "funding": [
         {
@@ -6673,7 +6673,7 @@
     },
     "node_modules/postcss-nested/node_modules/postcss-selector-parser": {
       "version": "6.1.2",
-      "resolved": "https://npm.registries.huggingface.tech/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "license": "MIT",
       "dependencies": {
@@ -6686,7 +6686,7 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "6.0.10",
-      "resolved": "https://npm.registries.huggingface.tech/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
       "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
       "dev": true,
       "license": "MIT",
@@ -6700,19 +6700,19 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "resolved": "https://npm.registries.huggingface.tech/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
     "node_modules/potpack": {
       "version": "1.0.2",
-      "resolved": "https://npm.registries.huggingface.tech/potpack/-/potpack-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
       "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
       "license": "ISC"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://npm.registries.huggingface.tech/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
@@ -6722,13 +6722,13 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
-      "resolved": "https://npm.registries.huggingface.tech/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
       "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6738,7 +6738,7 @@
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
-      "resolved": "https://npm.registries.huggingface.tech/prop-types/-/prop-types-15.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
       "dependencies": {
@@ -6749,7 +6749,7 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://npm.registries.huggingface.tech/punycode/-/punycode-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
@@ -6759,7 +6759,7 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://npm.registries.huggingface.tech/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "funding": [
         {
@@ -6779,7 +6779,7 @@
     },
     "node_modules/react": {
       "version": "18.3.1",
-      "resolved": "https://npm.registries.huggingface.tech/react/-/react-18.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
       "peer": true,
@@ -6792,7 +6792,7 @@
     },
     "node_modules/react-composer": {
       "version": "5.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/react-composer/-/react-composer-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/react-composer/-/react-composer-5.0.3.tgz",
       "integrity": "sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA==",
       "license": "MIT",
       "dependencies": {
@@ -6804,7 +6804,7 @@
     },
     "node_modules/react-day-picker": {
       "version": "8.10.2",
-      "resolved": "https://npm.registries.huggingface.tech/react-day-picker/-/react-day-picker-8.10.2.tgz",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.2.tgz",
       "integrity": "sha512-LK68OTbHB3oJNhl9cA0qVizzp3o26w61YSjAFkYi67N86iro32wx86kSNeFU/hq+gI8m1yzWhnomMLfZ041RzQ==",
       "license": "MIT",
       "funding": {
@@ -6818,7 +6818,7 @@
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
-      "resolved": "https://npm.registries.huggingface.tech/react-dom/-/react-dom-18.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
       "peer": true,
@@ -6832,7 +6832,7 @@
     },
     "node_modules/react-dom/node_modules/scheduler": {
       "version": "0.23.2",
-      "resolved": "https://npm.registries.huggingface.tech/scheduler/-/scheduler-0.23.2.tgz",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "license": "MIT",
       "dependencies": {
@@ -6841,7 +6841,7 @@
     },
     "node_modules/react-hook-form": {
       "version": "7.77.0",
-      "resolved": "https://npm.registries.huggingface.tech/react-hook-form/-/react-hook-form-7.77.0.tgz",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.77.0.tgz",
       "integrity": "sha512-Sslh9YDYc0GDlWT/lxasnIduNo4v3yyvqRGvmGKUre5AFjDs/HV9/OafHGD8d+sB2yoL4UIL9L8X9i0WlZZebg==",
       "license": "MIT",
       "peer": true,
@@ -6858,13 +6858,13 @@
     },
     "node_modules/react-is": {
       "version": "16.13.1",
-      "resolved": "https://npm.registries.huggingface.tech/react-is/-/react-is-16.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
     "node_modules/react-reconciler": {
       "version": "0.27.0",
-      "resolved": "https://npm.registries.huggingface.tech/react-reconciler/-/react-reconciler-0.27.0.tgz",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
       "integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
       "license": "MIT",
       "dependencies": {
@@ -6880,7 +6880,7 @@
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
-      "resolved": "https://npm.registries.huggingface.tech/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
       "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
       "license": "MIT",
       "dependencies": {
@@ -6905,7 +6905,7 @@
     },
     "node_modules/react-remove-scroll-bar": {
       "version": "2.3.8",
-      "resolved": "https://npm.registries.huggingface.tech/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
       "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
       "license": "MIT",
       "dependencies": {
@@ -6927,7 +6927,7 @@
     },
     "node_modules/react-resizable-panels": {
       "version": "2.1.9",
-      "resolved": "https://npm.registries.huggingface.tech/react-resizable-panels/-/react-resizable-panels-2.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-2.1.9.tgz",
       "integrity": "sha512-z77+X08YDIrgAes4jl8xhnUu1LNIRp4+E7cv4xHmLOxxUPO/ML7PSrE813b90vj7xvQ1lcf7g2uA9GeMZonjhQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -6937,7 +6937,7 @@
     },
     "node_modules/react-router": {
       "version": "6.30.4",
-      "resolved": "https://npm.registries.huggingface.tech/react-router/-/react-router-6.30.4.tgz",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
       "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
@@ -6952,7 +6952,7 @@
     },
     "node_modules/react-router-dom": {
       "version": "6.30.4",
-      "resolved": "https://npm.registries.huggingface.tech/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
       "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
@@ -6969,7 +6969,7 @@
     },
     "node_modules/react-smooth": {
       "version": "4.0.4",
-      "resolved": "https://npm.registries.huggingface.tech/react-smooth/-/react-smooth-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
       "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
       "license": "MIT",
       "dependencies": {
@@ -6984,7 +6984,7 @@
     },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
-      "resolved": "https://npm.registries.huggingface.tech/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
       "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
       "license": "MIT",
       "dependencies": {
@@ -7006,7 +7006,7 @@
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
-      "resolved": "https://npm.registries.huggingface.tech/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -7022,7 +7022,7 @@
     },
     "node_modules/react-use-measure": {
       "version": "2.1.7",
-      "resolved": "https://npm.registries.huggingface.tech/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
       "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
       "license": "MIT",
       "peerDependencies": {
@@ -7037,7 +7037,7 @@
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/read-cache/-/read-cache-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
       "license": "MIT",
       "dependencies": {
@@ -7046,7 +7046,7 @@
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
-      "resolved": "https://npm.registries.huggingface.tech/readable-stream/-/readable-stream-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
       "dependencies": {
@@ -7061,7 +7061,7 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
-      "resolved": "https://npm.registries.huggingface.tech/readdirp/-/readdirp-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "license": "MIT",
       "dependencies": {
@@ -7073,7 +7073,7 @@
     },
     "node_modules/recharts": {
       "version": "2.15.4",
-      "resolved": "https://npm.registries.huggingface.tech/recharts/-/recharts-2.15.4.tgz",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
       "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
       "deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
       "license": "MIT",
@@ -7097,7 +7097,7 @@
     },
     "node_modules/recharts-scale": {
       "version": "0.4.5",
-      "resolved": "https://npm.registries.huggingface.tech/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
       "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
       "license": "MIT",
       "dependencies": {
@@ -7106,13 +7106,13 @@
     },
     "node_modules/recharts/node_modules/react-is": {
       "version": "18.3.1",
-      "resolved": "https://npm.registries.huggingface.tech/react-is/-/react-is-18.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://npm.registries.huggingface.tech/require-from-string/-/require-from-string-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
@@ -7121,7 +7121,7 @@
     },
     "node_modules/resolve": {
       "version": "1.22.12",
-      "resolved": "https://npm.registries.huggingface.tech/resolve/-/resolve-1.22.12.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "license": "MIT",
       "dependencies": {
@@ -7142,7 +7142,7 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/resolve-from/-/resolve-from-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
@@ -7152,7 +7152,7 @@
     },
     "node_modules/reusify": {
       "version": "1.1.0",
-      "resolved": "https://npm.registries.huggingface.tech/reusify/-/reusify-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "license": "MIT",
       "engines": {
@@ -7162,7 +7162,7 @@
     },
     "node_modules/rolldown": {
       "version": "1.0.3",
-      "resolved": "https://npm.registries.huggingface.tech/rolldown/-/rolldown-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
       "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
@@ -7196,7 +7196,7 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://npm.registries.huggingface.tech/run-parallel/-/run-parallel-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "funding": [
         {
@@ -7219,13 +7219,13 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://npm.registries.huggingface.tech/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.21.0",
-      "resolved": "https://npm.registries.huggingface.tech/scheduler/-/scheduler-0.21.0.tgz",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
       "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
       "license": "MIT",
       "dependencies": {
@@ -7234,7 +7234,7 @@
     },
     "node_modules/semver": {
       "version": "7.8.2",
-      "resolved": "https://npm.registries.huggingface.tech/semver/-/semver-7.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
       "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
       "dev": true,
       "license": "ISC",
@@ -7247,13 +7247,13 @@
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://npm.registries.huggingface.tech/setimmediate/-/setimmediate-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
       "dependencies": {
@@ -7265,7 +7265,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
       "engines": {
@@ -7274,7 +7274,7 @@
     },
     "node_modules/sonner": {
       "version": "1.7.4",
-      "resolved": "https://npm.registries.huggingface.tech/sonner/-/sonner-1.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
       "integrity": "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==",
       "license": "MIT",
       "peerDependencies": {
@@ -7284,7 +7284,7 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://npm.registries.huggingface.tech/source-map-js/-/source-map-js-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
       "engines": {
@@ -7293,7 +7293,7 @@
     },
     "node_modules/stats-gl": {
       "version": "2.4.2",
-      "resolved": "https://npm.registries.huggingface.tech/stats-gl/-/stats-gl-2.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
       "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
       "license": "MIT",
       "dependencies": {
@@ -7307,19 +7307,19 @@
     },
     "node_modules/stats-gl/node_modules/three": {
       "version": "0.170.0",
-      "resolved": "https://npm.registries.huggingface.tech/three/-/three-0.170.0.tgz",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
       "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
       "license": "MIT"
     },
     "node_modules/stats.js": {
       "version": "0.17.0",
-      "resolved": "https://npm.registries.huggingface.tech/stats.js/-/stats.js-0.17.0.tgz",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
       "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
       "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
       "dependencies": {
@@ -7328,7 +7328,7 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
@@ -7341,7 +7341,7 @@
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
-      "resolved": "https://npm.registries.huggingface.tech/sucrase/-/sucrase-3.35.1.tgz",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
       "license": "MIT",
       "dependencies": {
@@ -7363,7 +7363,7 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://npm.registries.huggingface.tech/supports-color/-/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
@@ -7376,7 +7376,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://npm.registries.huggingface.tech/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "license": "MIT",
       "engines": {
@@ -7388,7 +7388,7 @@
     },
     "node_modules/suspend-react": {
       "version": "0.1.3",
-      "resolved": "https://npm.registries.huggingface.tech/suspend-react/-/suspend-react-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
       "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -7397,7 +7397,7 @@
     },
     "node_modules/tailwind-merge": {
       "version": "2.6.1",
-      "resolved": "https://npm.registries.huggingface.tech/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
       "integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
       "license": "MIT",
       "funding": {
@@ -7407,7 +7407,7 @@
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
-      "resolved": "https://npm.registries.huggingface.tech/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
       "peer": true,
@@ -7445,7 +7445,7 @@
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
-      "resolved": "https://npm.registries.huggingface.tech/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
       "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
       "license": "MIT",
       "peerDependencies": {
@@ -7454,7 +7454,7 @@
     },
     "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
       "version": "6.1.2",
-      "resolved": "https://npm.registries.huggingface.tech/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "license": "MIT",
       "dependencies": {
@@ -7467,7 +7467,7 @@
     },
     "node_modules/thenify": {
       "version": "3.3.1",
-      "resolved": "https://npm.registries.huggingface.tech/thenify/-/thenify-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "license": "MIT",
       "dependencies": {
@@ -7476,7 +7476,7 @@
     },
     "node_modules/thenify-all": {
       "version": "1.6.0",
-      "resolved": "https://npm.registries.huggingface.tech/thenify-all/-/thenify-all-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
       "license": "MIT",
       "dependencies": {
@@ -7488,14 +7488,14 @@
     },
     "node_modules/three": {
       "version": "0.177.0",
-      "resolved": "https://npm.registries.huggingface.tech/three/-/three-0.177.0.tgz",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.177.0.tgz",
       "integrity": "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.7.8",
-      "resolved": "https://npm.registries.huggingface.tech/three-mesh-bvh/-/three-mesh-bvh-0.7.8.tgz",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.7.8.tgz",
       "integrity": "sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw==",
       "deprecated": "Deprecated due to three.js version incompatibility. Please use v0.8.0, instead.",
       "license": "MIT",
@@ -7505,7 +7505,7 @@
     },
     "node_modules/three-stdlib": {
       "version": "2.36.1",
-      "resolved": "https://npm.registries.huggingface.tech/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
       "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
       "license": "MIT",
       "dependencies": {
@@ -7522,19 +7522,19 @@
     },
     "node_modules/three-stdlib/node_modules/fflate": {
       "version": "0.6.10",
-      "resolved": "https://npm.registries.huggingface.tech/fflate/-/fflate-0.6.10.tgz",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
       "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
       "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
-      "resolved": "https://npm.registries.huggingface.tech/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://npm.registries.huggingface.tech/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
@@ -7550,7 +7550,7 @@
     },
     "node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://npm.registries.huggingface.tech/fdir/-/fdir-6.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "license": "MIT",
       "engines": {
@@ -7567,7 +7567,7 @@
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://npm.registries.huggingface.tech/picomatch/-/picomatch-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "peer": true,
@@ -7580,7 +7580,7 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://npm.registries.huggingface.tech/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "license": "MIT",
       "dependencies": {
@@ -7592,7 +7592,7 @@
     },
     "node_modules/troika-three-text": {
       "version": "0.52.4",
-      "resolved": "https://npm.registries.huggingface.tech/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
       "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
       "license": "MIT",
       "dependencies": {
@@ -7607,7 +7607,7 @@
     },
     "node_modules/troika-three-utils": {
       "version": "0.52.4",
-      "resolved": "https://npm.registries.huggingface.tech/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
       "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
       "license": "MIT",
       "peerDependencies": {
@@ -7616,13 +7616,13 @@
     },
     "node_modules/troika-worker-utils": {
       "version": "0.52.0",
-      "resolved": "https://npm.registries.huggingface.tech/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
       "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
-      "resolved": "https://npm.registries.huggingface.tech/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
@@ -7635,19 +7635,19 @@
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
-      "resolved": "https://npm.registries.huggingface.tech/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://npm.registries.huggingface.tech/tslib/-/tslib-2.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/tunnel-rat": {
       "version": "0.1.2",
-      "resolved": "https://npm.registries.huggingface.tech/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
       "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
       "license": "MIT",
       "dependencies": {
@@ -7656,7 +7656,7 @@
     },
     "node_modules/tunnel-rat/node_modules/zustand": {
       "version": "4.5.7",
-      "resolved": "https://npm.registries.huggingface.tech/zustand/-/zustand-4.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
       "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
       "license": "MIT",
       "dependencies": {
@@ -7684,7 +7684,7 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://npm.registries.huggingface.tech/type-check/-/type-check-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
@@ -7697,7 +7697,7 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://npm.registries.huggingface.tech/typescript/-/typescript-5.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -7712,7 +7712,7 @@
     },
     "node_modules/typescript-eslint": {
       "version": "8.60.1",
-      "resolved": "https://npm.registries.huggingface.tech/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
       "integrity": "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==",
       "dev": true,
       "license": "MIT",
@@ -7736,14 +7736,14 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://npm.registries.huggingface.tech/undici-types/-/undici-types-6.21.0.tgz",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://npm.registries.huggingface.tech/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
@@ -7774,7 +7774,7 @@
     },
     "node_modules/urdf-loader": {
       "version": "0.12.7",
-      "resolved": "https://npm.registries.huggingface.tech/urdf-loader/-/urdf-loader-0.12.7.tgz",
+      "resolved": "https://registry.npmjs.org/urdf-loader/-/urdf-loader-0.12.7.tgz",
       "integrity": "sha512-9RQDhWt4x9K6R3uHjv68NLwX+JDm3A2XjhksrMgq6xl9NJcwqV21+htHU0cbG619hnqH1d4mUMFuqHo22R8DMA==",
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -7783,7 +7783,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://npm.registries.huggingface.tech/uri-js/-/uri-js-4.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -7793,7 +7793,7 @@
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
-      "resolved": "https://npm.registries.huggingface.tech/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
       "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
       "license": "MIT",
       "dependencies": {
@@ -7814,7 +7814,7 @@
     },
     "node_modules/use-sidecar": {
       "version": "1.1.3",
-      "resolved": "https://npm.registries.huggingface.tech/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
       "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
       "license": "MIT",
       "dependencies": {
@@ -7836,7 +7836,7 @@
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
-      "resolved": "https://npm.registries.huggingface.tech/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
       "peerDependencies": {
@@ -7845,13 +7845,13 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://npm.registries.huggingface.tech/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
     "node_modules/utility-types": {
       "version": "3.11.0",
-      "resolved": "https://npm.registries.huggingface.tech/utility-types/-/utility-types-3.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
       "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
       "license": "MIT",
       "engines": {
@@ -7860,7 +7860,7 @@
     },
     "node_modules/vaul": {
       "version": "0.9.9",
-      "resolved": "https://npm.registries.huggingface.tech/vaul/-/vaul-0.9.9.tgz",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-0.9.9.tgz",
       "integrity": "sha512-7afKg48srluhZwIkaU+lgGtFCUsYBSGOl8vcc8N/M3YQlZFlynHD15AE+pwrYdc826o7nrIND4lL9Y6b9WWZZQ==",
       "license": "MIT",
       "dependencies": {
@@ -7873,7 +7873,7 @@
     },
     "node_modules/victory-vendor": {
       "version": "36.9.2",
-      "resolved": "https://npm.registries.huggingface.tech/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
       "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
       "license": "MIT AND ISC",
       "dependencies": {
@@ -7895,7 +7895,7 @@
     },
     "node_modules/vite": {
       "version": "8.0.16",
-      "resolved": "https://npm.registries.huggingface.tech/vite/-/vite-8.0.16.tgz",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
@@ -7974,7 +7974,7 @@
     },
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://npm.registries.huggingface.tech/picomatch/-/picomatch-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -7987,18 +7987,18 @@
     },
     "node_modules/webgl-constants": {
       "version": "1.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
       "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
     },
     "node_modules/webgl-sdf-generator": {
       "version": "1.1.1",
-      "resolved": "https://npm.registries.huggingface.tech/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
       "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
       "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://npm.registries.huggingface.tech/which/-/which-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
       "dependencies": {
@@ -8013,7 +8013,7 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://npm.registries.huggingface.tech/word-wrap/-/word-wrap-1.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
@@ -8023,7 +8023,7 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://npm.registries.huggingface.tech/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
@@ -8036,7 +8036,7 @@
     },
     "node_modules/zod": {
       "version": "3.25.76",
-      "resolved": "https://npm.registries.huggingface.tech/zod/-/zod-3.25.76.tgz",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
@@ -8045,7 +8045,7 @@
     },
     "node_modules/zustand": {
       "version": "5.0.14",
-      "resolved": "https://npm.registries.huggingface.tech/zustand/-/zustand-5.0.14.tgz",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
       "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Problem

The HF Space (`lerobot/LeLab`) Docker build fails: `npm` hangs ~8 minutes on the dependency install, then crashes with:

```
npm error Exit handler never called!
```

## Root cause

`frontend/package-lock.json` had **all 530 `resolved` tarball URLs pinned to the internal mirror `npm.registries.huggingface.tech`** — baked in by a global `~/.npmrc` (`registry=...huggingface.tech`, `min-release-age=7`) on the machine that generated the lockfile. `npm ci`/`npm install` fetch those exact URLs regardless of the configured registry.

That mirror times out (`ETIMEDOUT`) serving the Vite 8 dependency set (e.g. `vite-8.0.16.tgz`, `victory-vendor`, `vaul`, …). npm exhausts its retry budget (~8 min) and npm 10.9.x surfaces the failed timeout as the internal `Exit handler never called!` crash rather than a clean network error. The recent vite 5→8 bump introduced tarballs the mirror can't serve.

## Fix

- Repoint every `resolved` URL in `package-lock.json` from `npm.registries.huggingface.tech` → `registry.npmjs.org`. Package **versions and `integrity` hashes are unchanged** (integrity is content-based), so this is the exact same dependency tree, just fetched from the public registry.
- Switch the Dockerfile from `npm install` to `npm ci`, which installs strictly from the lockfile's `resolved` URLs and ignores the builder's configured registry — a slow/incomplete mirror can no longer derail the build.

## Verification

Reproduced the exact Space build flow on `node:22-alpine` via HF Jobs:

| Step | Before (mirror URLs) | After (public URLs) |
|------|----------------------|---------------------|
| `npm ci` | 8 min → `Exit handler never called!` | **6.9s ✓** |
| `npm run build` | n/a (never reached) | **vite build OK, `dist/` produced ✓** |