### PR TITLE
fix(train): correct pi0_fast policy type value in dropdown

### DIFF
--- a/frontend/src/components/training/config/EssentialsCard.tsx
+++ b/frontend/src/components/training/config/EssentialsCard.tsx
@@ -94,7 +94,7 @@ const EssentialsCard: React.FC<EssentialsCardProps> = ({ config, updateConfig, d
                 <SelectItem value="smolvla">SmolVLA</SelectItem>
                 <SelectItem value="tdmpc">TD-MPC</SelectItem>
                 <SelectItem value="vqbet">VQ-BeT</SelectItem>
-                <SelectItem value="pi0fast">PI0 Fast</SelectItem>
+                <SelectItem value="pi0_fast">PI0 Fast</SelectItem>
                 <SelectItem value="sac">SAC</SelectItem>
                 <SelectItem value="reward_classifier">Reward Classifier</SelectItem>
               </SelectContent>


### PR DESCRIPTION
## Problem

Selecting **PI0 Fast** in the training policy dropdown failed with:

```
lerobot_train.py: error: argument --policy.type: invalid choice: 'pi0fast'
(choose from act, diffusion, ..., pi0_fast)
```

The dropdown sent `pi0fast`, but LeRobot's `--policy.type` expects `pi0_fast` (with underscore). The backend already uses the correct name in `_LANGUAGE_CONDITIONED_POLICY_TYPES` (`lelab/jobs.py`); only the frontend `SelectItem` value was wrong.

## Fix

One-line change in `frontend/src/components/training/config/EssentialsCard.tsx`: `pi0fast` → `pi0_fast`.

The committed `frontend/dist/` bundle is intentionally not included — `build_frontend.yml` regenerates and commits it automatically once this lands on `main`.

Fixes #15
