### PR TITLE
feat(system): warn when an NVIDIA GPU is present but PyTorch can't use CUDA

### DIFF
--- a/lelab/server.py
+++ b/lelab/server.py
@@ -99,12 +99,14 @@ from .utils.config import (
 )
 from .utils.hf_auth import cached_whoami, handle_hf_auth_status, handle_hf_login, shared_hf_api
 from .utils.system import (
+    handle_get_cuda_status,
     handle_get_training_extra,
     handle_get_wandb_extra,
     handle_install_training_extra,
     handle_install_training_extra_status,
     handle_install_wandb_extra,
     handle_install_wandb_extra_status,
+    warn_if_cuda_mismatch,
 )
 
 # Set up logging
@@ -691,6 +693,12 @@ def get_runners_hardware():
 # ============================================================================
 
 
+@app.get("/system/cuda-status")
+def get_cuda_status():
+    """Report whether an NVIDIA GPU is present but PyTorch is CPU-only (issue #30)."""
+    return handle_get_cuda_status()
+
+
 @app.get("/system/training-extra")
 def get_training_extra():
     """Return whether the LeRobot training extra (accelerate) is importable."""
@@ -1158,6 +1166,12 @@ def delete_robot(name: str):
     if delete_robot_record(name):
         return {"status": "success"}
     return JSONResponse(status_code=404, content={"status": "error", "message": "Robot not found"})
+
+
+@app.on_event("startup")
+def startup_event():
+    """One-time startup diagnostics surfaced in the server terminal."""
+    warn_if_cuda_mismatch()
 
 
 @app.on_event("shutdown")

--- a/lelab/utils/system.py
+++ b/lelab/utils/system.py
@@ -55,6 +55,15 @@ class ExtraStatus(BaseModel):
     install_hint: str
 
 
+class CudaStatus(BaseModel):
+    gpu_present: bool
+    cuda_available: bool
+    mismatch: bool
+    torch_version: str | None = None
+    install_hint: str
+    docs_url: str
+
+
 class InstallStartResponse(BaseModel):
     started: bool
     message: str
@@ -175,3 +184,85 @@ def handle_install_wandb_extra() -> dict[str, Any]:
 
 def handle_install_wandb_extra_status() -> dict[str, Any]:
     return wandb_install_manager.get_status()
+
+
+# Detect the common Windows/LeLab mismatch where an NVIDIA GPU is visible to the
+# OS, but the active PyTorch build cannot use CUDA. Do not auto-install torch.
+
+CUDA_TORCH_DOCS_URL = "https://pytorch.org/get-started/locally/"
+CUDA_TORCH_INSTALL_HINT = (
+    "To use the GPU, install a CUDA build of PyTorch. Pick your CUDA version at "
+    f"{CUDA_TORCH_DOCS_URL} "
+    "(for example: pip install torch --index-url https://download.pytorch.org/whl/cu124), "
+    "then restart LeLab."
+)
+
+
+def _nvidia_gpu_present() -> bool:
+    """True if an NVIDIA GPU is visible to the OS (``nvidia-smi -L`` lists one).
+
+    Dependency-free and cheap: requires nvidia-smi on PATH, then confirms it
+    actually reports a GPU. Any failure (no driver, no GPU, timeout) → False.
+    """
+    if not shutil.which("nvidia-smi"):
+        return False
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "-L"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0 and result.stdout.strip().startswith("GPU")
+
+
+def _torch_cuda() -> tuple[bool, str | None]:
+    """Return (cuda_available, torch_version). Missing/broken torch → (False, None)."""
+    try:
+        import torch
+    except Exception:  # torch absent or import error — treat as no CUDA
+        logger.debug("torch import failed during CUDA check", exc_info=True)
+        return False, None
+    try:
+        return bool(torch.cuda.is_available()), torch.__version__
+    except Exception:
+        logger.debug("torch.cuda.is_available() raised", exc_info=True)
+        return False, getattr(torch, "__version__", None)
+
+
+def detect_cuda_status() -> dict[str, Any]:
+    """Detect the 'NVIDIA GPU present but PyTorch is CPU-only' mismatch (issue #30)."""
+    gpu_present = _nvidia_gpu_present()
+    cuda_available, torch_version = _torch_cuda()
+    return {
+        "gpu_present": gpu_present,
+        "cuda_available": cuda_available,
+        "mismatch": gpu_present and not cuda_available,
+        "torch_version": torch_version,
+        "install_hint": CUDA_TORCH_INSTALL_HINT,
+        "docs_url": CUDA_TORCH_DOCS_URL,
+    }
+
+
+def handle_get_cuda_status() -> dict[str, Any]:
+    return detect_cuda_status()
+
+
+def warn_if_cuda_mismatch() -> None:
+    """Log a prominent warning when a GPU is present but torch is CPU-only.
+
+    Called at server startup so the user sees actionable guidance in the same
+    terminal where LeRobot's easily-missed 'Switching to cpu' line appears.
+    """
+    status = detect_cuda_status()
+    if not status["mismatch"]:
+        return
+    logger.warning(
+        "⚠️  NVIDIA GPU detected but PyTorch can't use CUDA (torch=%s). "
+        "Training and inference will run on CPU and may be much slower. %s",
+        status["torch_version"],
+        status["install_hint"],
+    )

--- a/tests/test_utils_system.py
+++ b/tests/test_utils_system.py
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for lelab.utils.system — pip-extra install helpers."""
+"""Tests for lelab.utils.system — pip-extra install helpers + CUDA detection."""
 
 from __future__ import annotations
 
+import logging
 import sys
 
 
@@ -51,3 +52,78 @@ def test_install_manager_initial_state_is_idle() -> None:
     assert status["state"] == "idle"
     assert status["error"] is None
     assert isinstance(status["logs"], list)
+
+
+# --- CUDA / GPU mismatch detection (issue #30) --------------------------------
+
+
+def test_detect_cuda_status_flags_mismatch_when_gpu_but_cpu_torch(monkeypatch) -> None:
+    """GPU present + no CUDA in PyTorch should report a mismatch."""
+    from lelab.utils import system
+
+    monkeypatch.setattr(system, "_nvidia_gpu_present", lambda: True)
+    monkeypatch.setattr(system, "_torch_cuda", lambda: (False, "2.10.0+cpu"))
+
+    status = system.detect_cuda_status()
+    assert status["gpu_present"] is True
+    assert status["cuda_available"] is False
+    assert status["mismatch"] is True
+    assert status["torch_version"] == "2.10.0+cpu"
+    assert status["docs_url"].startswith("https://pytorch.org")
+
+
+def test_detect_cuda_status_no_mismatch_when_cuda_available(monkeypatch) -> None:
+    from lelab.utils import system
+
+    monkeypatch.setattr(system, "_nvidia_gpu_present", lambda: True)
+    monkeypatch.setattr(system, "_torch_cuda", lambda: (True, "2.10.0+cu124"))
+
+    assert system.detect_cuda_status()["mismatch"] is False
+
+
+def test_detect_cuda_status_no_mismatch_without_gpu(monkeypatch) -> None:
+    """No GPU (e.g. a Mac/CPU box) must not nag — CPU torch is expected there."""
+    from lelab.utils import system
+
+    monkeypatch.setattr(system, "_nvidia_gpu_present", lambda: False)
+    monkeypatch.setattr(system, "_torch_cuda", lambda: (False, "2.10.0+cpu"))
+
+    assert system.detect_cuda_status()["mismatch"] is False
+
+
+def test_nvidia_gpu_present_false_when_smi_absent(monkeypatch) -> None:
+    import shutil
+
+    from lelab.utils import system
+
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    assert system._nvidia_gpu_present() is False
+
+
+def test_warn_if_cuda_mismatch_logs_on_mismatch(monkeypatch, caplog) -> None:
+    from lelab.utils import system
+
+    monkeypatch.setattr(system, "_nvidia_gpu_present", lambda: True)
+    monkeypatch.setattr(system, "_torch_cuda", lambda: (False, "2.10.0+cpu"))
+
+    with caplog.at_level(logging.WARNING, logger="lelab.utils.system"):
+        system.warn_if_cuda_mismatch()
+    assert any("use CUDA" in rec.message for rec in caplog.records)
+
+
+def test_warn_if_cuda_mismatch_silent_when_ok(monkeypatch, caplog) -> None:
+    from lelab.utils import system
+
+    monkeypatch.setattr(system, "_nvidia_gpu_present", lambda: True)
+    monkeypatch.setattr(system, "_torch_cuda", lambda: (True, "2.10.0+cu124"))
+
+    with caplog.at_level(logging.WARNING, logger="lelab.utils.system"):
+        system.warn_if_cuda_mismatch()
+    assert caplog.records == []
+
+
+def test_cuda_status_endpoint_returns_expected_shape(client) -> None:
+    response = client.get("/system/cuda-status")
+    assert response.status_code == 200
+    body = response.json()
+    assert set(body) >= {"gpu_present", "cuda_available", "mismatch", "install_hint", "docs_url"}


### PR DESCRIPTION
## What does this PR do?

Addresses #30. When an NVIDIA GPU is installed but the active PyTorch can't use
CUDA, LeRobot silently downgrades `--policy.device cuda` to CPU so the only signal
is one easily overlooked line mid-log:

```
Device 'cuda' is not available. Switching to 'cpu'.
No accelerated backend detected.
```

Training and inference then crawl on CPU with no actionable guidance. This PR
surfaces the mismatch proactively without reinstalling Pytorch:

- A prominent startup WARNING in the server terminal (where the user already
  sees LeRobot's log line) with the guidance of:
  ```
  ⚠️  NVIDIA GPU detected but PyTorch can't use CUDA (torch=2.10.0+cpu). Training
  and inference will run on CPU and may be much slower. To use the GPU, install a
  CUDA build of PyTorch. Pick your CUDA version at
  https://pytorch.org/get-started/locally/ (for example: pip install torch
  --index-url https://download.pytorch.org/whl/cu124), then restart LeLab.
  ```
- A new `GET /system/cuda-status` endpoint returning
  `{gpu_present, cuda_available, mismatch, torch_version, install_hint, docs_url}`
  so the frontend can show a banner (follow-up, see below).

## Why this happens (and why it mostly happens on Windows)

With a plain dependency install, PyTorch resolution is platform-dependent. The
uv PyTorch guide documents that PyPI hosts CPU-only wheels for Windows/macOS,
while Linux PyPI wheels are GPU-accelerated by default. CUDA-specific builds are
also published on PyTorch's own indexes (`download.pytorch.org/whl/cuXXX`) when
a project wants to opt into a particular CUDA variant.

LeRobot declares a `torch` dependency, but its accelerator docs tell users to
install a suitable PyTorch build for their backend ([lerobot accelerators](https://huggingface.co/docs/lerobot/torch_accelerators)). So on Windows,
installing LeLab can pull the CPU-only torch wheel transitively, exactly like the reporter's
`2.10.0+cpu`.

## Scope: "Addresses", not "Fixes"

The issue suggests auto-installing CUDA PyTorch. I deliberately didn't:

the correct CUDA wheel depends on the user's driver/CUDA version, the build is
large, and silently replacing a working `torch` at runtime can break the env (and
some users want CPU-only on purpose). So this PR fixes the part that's genuinely
LeLab's job i.e. turning a silent fallback into a louder, actionable one but
it doesn't make the GPU just work.

## How it works

- `lelab/utils/system.py`:
  - `_nvidia_gpu_present()` — dependency-free: `nvidia-smi` on PATH + `nvidia-smi
    -L` actually lists a GPU. Any failure → `False`.
  - `_torch_cuda()` — `(torch.cuda.is_available(), torch.__version__)`; missing/
    broken torch → `(False, None)`.
  - `detect_cuda_status()` / `warn_if_cuda_mismatch()` / `CudaStatus` model.
- `lelab/server.py`: `GET /system/cuda-status` + an `@app.on_event("startup")`
  hook calling `warn_if_cuda_mismatch()` (matches the file's existing
  `@app.on_event("shutdown")` style; happy to migrate both to `lifespan`).

## Notes

- No behavior change beyond the warning/endpoint; device selection is untouched.
- No-GPU machines (Macs, CPU boxes) are not nagged: CPU torch is expected there.

## Tests

`tests/test_utils_system.py` (+7): mismatch flagged (GPU + no-CUDA torch),
no-mismatch when CUDA available, no-mismatch without a GPU, `nvidia-smi` absent →
False, warn logs on mismatch / silent when OK, and the endpoint shape. `pytest` +
`ruff check` + `ruff format` + the full pre-commit (bandit, mypy) green; rest of
the suite unaffected.

## Possible follow-up

An opt-in "Install CUDA PyTorch" action driven by `/system/cuda-status`,
reusing LeLab's existing `InstallManager` (which already does `pip install
accelerate`/`wandb`) pointed at the CUDA index — showing the exact command before
running it, never silently. Plus a frontend banner so the warning is visible in
the UI, not just the terminal.