### PR TITLE
fix(calibration): persist detected/edited port to robot record

### DIFF
--- a/frontend/src/pages/Calibration.tsx
+++ b/frontend/src/pages/Calibration.tsx
@@ -445,8 +445,36 @@ const Calibration = () => {
     setShowPortDetection(true);
   };
 
+  // Write the port for the current side straight into the robot record, so a
+  // re-detected USB port (which shuffles on reboot/reconnect) sticks without
+  // needing a full re-calibration. Mirrors the camera write-back above.
+  const persistPort = useCallback(
+    async (nextPort: string) => {
+      if (!robotName || !nextPort) return;
+      const field = deviceType === "robot" ? "follower_port" : "leader_port";
+      // Skip redundant writes when the value already matches the record.
+      if (robot && robot[field] === nextPort) return;
+      try {
+        const res = await fetchWithHeaders(
+          `${baseUrl}/robots/${encodeURIComponent(robotName)}`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ [field]: nextPort }),
+          }
+        );
+        const data = await res.json();
+        if (data.robot) setRobot(data.robot);
+      } catch (e) {
+        console.error("Failed to save port to robot record:", e);
+      }
+    },
+    [robotName, deviceType, robot, baseUrl, fetchWithHeaders]
+  );
+
   const handlePortDetected = (detectedPort: string) => {
     setPort(detectedPort);
+    persistPort(detectedPort);
   };
 
   const getStatusDisplay = () => {
@@ -575,6 +603,7 @@ const Calibration = () => {
                     id="port"
                     value={port}
                     onChange={(e) => setPort(e.target.value)}
+                    onBlur={(e) => persistPort(e.target.value)}
                     placeholder="/dev/tty.usbmodem..."
                     className="bg-slate-700 border-slate-600 text-white rounded-md flex-1"
                   />


### PR DESCRIPTION
## Problem

USB ports for the SO-101 arms shuffle on reboot/reconnect. When that happens, the only way to get the new port saved was to run a **full calibration** — because the robot record's `leader_port`/`follower_port` (the fields teleop and recording actually read) are only written back when a calibration *completes* (`calibrate.py`).

The "Find" port-detection flow and manual edits of the Port field only updated local form state (`handlePortDetected` → `setPort`) — and the legacy global `*_port.txt` file, which nothing important reads anymore. So a re-detected port never reached the robot record without sitting through calibration again. Reported as a recurring quality-of-life pain.

## Fix

Persist the port for the current side straight into the robot record:

- **On detection** — `handlePortDetected` now writes the detected port to `/robots/{name}` (`leader_port` or `follower_port` depending on the selected device type).
- **On manual edit** — the Port input persists on blur.

This mirrors the existing camera write-back pattern already in `Calibration.tsx`. Redundant writes (value unchanged or empty) are skipped. No backend change — the `/robots/{name}` POST already merges partial patches.

## Test

- `tsc --noEmit` clean
- `eslint` clean