### PR TITLE
fix(update): use 'uv tool install --force' for uv-tool installs

### DIFF
--- a/lelab/update.py
+++ b/lelab/update.py
@@ -31,6 +31,7 @@ import sys
 import time
 import urllib.request
 from importlib.metadata import PackageNotFoundError, distribution
+from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel
@@ -127,14 +128,28 @@ def _github_json(path: str) -> Any | None:
         return None
 
 
-def _build_update_cmd(owner: str, repo: str) -> list[str]:
-    """Pick the installer for the running Python.
+def _is_uv_tool_install() -> bool:
+    """True when LeLab runs from a `uv tool install` (the standard install).
 
-    The hosted/standard install uses uv (uv venvs ship no pip), so prefer
-    `uv pip install` pinned to this interpreter when uv is on PATH, matching
-    the extra-install flow in utils/system.py. Fall back to `python -m pip`.
+    uv tools live in an isolated env under `<data>/uv/tools/<name>/`, so the
+    running interpreter sits inside a `uv/tools` path segment.
+    """
+    return "uv/tools" in Path(sys.executable).as_posix()
+
+
+def _build_update_cmd(owner: str, repo: str) -> list[str]:
+    """Pick the right updater for how LeLab was installed.
+
+    - Standard install is `uv tool install`: update the tool in place with
+      `--force`, which re-fetches the latest commit even though the version
+      string is unchanged.
+    - uv venv install: `uv pip install` pinned to this interpreter (uv venvs
+      ship no pip), matching the extra-install flow in utils/system.py.
+    - Plain pip env: `python -m pip install`.
     """
     target = f"git+https://github.com/{owner}/{repo}.git"
+    if shutil.which("uv") and _is_uv_tool_install():
+        return ["uv", "tool", "install", "--force", target]
     flags = ["--upgrade", "--force-reinstall", target]
     if shutil.which("uv"):
         return ["uv", "pip", "install", "--python", sys.executable, *flags]

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -147,3 +147,26 @@ def test_run_update_no_source(monkeypatch):
     monkeypatch.setattr(update, "get_installed_source", lambda: None)
     result = update.handle_run_update()
     assert result.success is False
+
+
+def test_update_command_for_uv_tool_install(monkeypatch):
+    """Standard `uv tool install` setup updates the tool in place with --force."""
+    monkeypatch.setattr(update.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(update, "_is_uv_tool_install", lambda: True)
+    cmd = update._build_update_cmd("huggingface", "leLab")
+    assert cmd == [
+        "uv",
+        "tool",
+        "install",
+        "--force",
+        "git+https://github.com/huggingface/leLab.git",
+    ]
+
+
+def test_update_command_for_pip_env(monkeypatch):
+    """A plain pip environment (no uv) updates via `python -m pip`."""
+    monkeypatch.setattr(update.shutil, "which", lambda name: None)
+    monkeypatch.setattr(update, "_is_uv_tool_install", lambda: False)
+    cmd = update._build_update_cmd("huggingface", "leLab")
+    assert cmd[:4] == [update.sys.executable, "-m", "pip", "install"]
+    assert "--force-reinstall" in cmd


### PR DESCRIPTION
## Problem

The update notifier (#38) assumed a pip/venv install, but the **standard install is `uv tool install git+https://github.com/huggingface/leLab.git`** — an isolated uv *tool* environment, not an activated venv.

For those installs, the previous command (`uv pip install --python … --force-reinstall …` / `pip install …`) targets the wrong environment: there's no active venv, and the tool's env isn't managed via `uv pip`. So the displayed command and the **Update now** button would not actually update a standard install.

## Fix

Detect a uv-tool install — the running interpreter lives under `…/uv/tools/<name>/` — and update it in place with:

```
uv tool install --force git+https://github.com/huggingface/leLab.git
```

`--force` reinstalls even though the version string is unchanged (`0.1.0`), so it re-fetches the latest commit. This mirrors the install command, just with `--force`.

Fallbacks are unchanged: `uv pip install` for uv venvs, `python -m pip install` for plain pip environments. As before, the displayed command is exactly what **Update now** executes.

## Tests

Added `test_update_command_for_uv_tool_install` and `test_update_command_for_pip_env`; full update suite (17) passes, pre-commit clean.