### PR TITLE
Fix LeRobot env eval frequency flag

### DIFF
--- a/lelab/train.py
+++ b/lelab/train.py
@@ -135,7 +135,7 @@ def build_training_command(
     # Logging / checkpointing
     cmd.extend(["--log_freq", str(request.log_freq)])
     cmd.extend(["--save_freq", str(request.save_freq)])
-    cmd.extend(["--eval_freq", str(request.eval_freq)])
+    cmd.extend(["--env_eval_freq", str(request.eval_freq)])
     cmd.extend(["--save_checkpoint", "true" if request.save_checkpoint else "false"])
 
     # Output


### PR DESCRIPTION
This PR updates LeLab's training command builder to use the current LeRobot CLI flag for environment evaluation frequency.
Fixes Issue #51 

LeRobot renamed `--eval_freq` to `--env_eval_freq` in huggingface/lerobot#3824. LeLab still emits the old flag, causing cloud training jobs to fail before training starts with:

```text
lerobot_train.py: error: unrecognized arguments: --eval_freq 0