### PR TITLE
Feat/gripper force feedback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Run the Python tests with `pytest` (config in [pyproject.toml](pyproject.toml); 
 [server.py](lelab/server.py) is a thin FastAPI router. Each feature lives in its own module that owns its global state and exposes `handle_*` functions plus a Pydantic request model:
 
 - [record.py](lelab/record.py) — dataset recording (wraps `lerobot.record.record`); patches `lerobot.common.utils.control_utils` keyboard listener so frontend buttons replace arrow-key controls.
-- [teleoperate.py](lelab/teleoperate.py) — leader→follower teleoperation (wraps `lerobot.teleoperate`).
+- [teleoperate.py](lelab/teleoperate.py) — leader→follower teleoperation; optional gripper-only force feedback ([GRIPPER_FORCE_FEEDBACK.md](GRIPPER_FORCE_FEEDBACK.md)).
 - [calibrate.py](lelab/calibrate.py) — step-by-step web calibration with a `CalibrationManager` singleton and `_step_complete` threading.Event.
 - [train.py](lelab/train.py) — wraps the LeRobot training CLI as a subprocess (psutil for lifecycle, queue for log streaming).
 - [utils/config.py](lelab/utils/config.py) — shared paths and persistence: calibration JSON, saved ports, saved config selections. **Import shared constants from here, do not hardcode paths in feature modules.**

--- a/GRIPPER_FORCE_FEEDBACK.md
+++ b/GRIPPER_FORCE_FEEDBACK.md
@@ -1,0 +1,81 @@
+# Gripper force feedback (teleoperation)
+
+Optional haptic feedback for SO-101 leader–follower teleoperation. When enabled, the **leader gripper only** resists squeezing past the point where the **follower** has stopped on a grasped object.
+
+Arm joints stay back-drivable (torque off) at all times; only the leader gripper motor is powered when feedback is active.
+
+## Enabling in the UI
+
+1. On the **Landing** page, select a configured robot.
+2. Check **Gripper force feedback** above the **Teleoperation** button.
+3. Start teleoperation as usual.
+
+In dev mode, use the Vite UI at `http://localhost:8080` so you see the latest frontend. The production bundle on `:8000` is rebuilt by CI when `frontend/` changes merge to `main`.
+
+## API
+
+`POST /move-arm` accepts two optional fields on `TeleoperateRequest`:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `gripper_force_feedback` | `bool` | `false` | Enable gripper-only force feedback |
+| `gripper_force_feedback_gain` | `float` | `1.0` | Resistance strength multiplier (0.1–3.0) |
+
+`GET /teleoperation-status` includes:
+
+- `gripper_force_feedback` — whether feedback was enabled for the active session
+- `stop_reason` — why the session ended (user stop, communication errors, etc.)
+
+## How it works
+
+Each control-loop iteration (when feedback is enabled):
+
+1. Read follower gripper `Present_Load` and `Present_Position`.
+2. Read leader gripper `Present_Position`.
+3. Decide whether to apply feedback:
+
+| Condition | Feedback |
+|-----------|----------|
+| Follower load below deadband (~20) | **Off** — no grasp detected |
+| Leader within ~2 units of follower position | **Off** — arms in sync |
+| Leader squeezed **past** follower position while loaded | **On** — virtual wall at follower position |
+| Leader moving back toward follower (releasing) | **Off** — no resistance while opening |
+
+When active, torque is enabled on the **leader gripper only**. The motor goal is set to the follower’s current gripper position (a virtual wall). Resistance torque scales with how far the leader is past that wall and with `gripper_force_feedback_gain`.
+
+When inactive, leader gripper torque is disabled so the trigger stays free to move.
+
+## Teleoperation robustness
+
+Related changes in the same module improve session stability:
+
+- **Transient serial errors** — the loop tolerates up to 50 consecutive bus read/write failures before disconnecting.
+- **Unexpected session end** — the teleoperation page polls `/teleoperation-status` every 2s and shows a toast with `stop_reason` if the backend worker exits.
+- **bfcache** — `pagehide` no longer stops teleoperation when the page is cached for back-navigation (`event.persisted`).
+
+## Tuning constants
+
+Defined at the top of [`lelab/teleoperate.py`](lelab/teleoperate.py):
+
+| Constant | Default | Effect |
+|----------|---------|--------|
+| `_GRIPPER_LOAD_DEADBAND` | `20` | Minimum follower load to treat as a grasp |
+| `_GRIPPER_POSITION_MARGIN` | `2.0` | Leader–follower gap before resistance starts (RANGE_0_100 units) |
+| `_GRIPPER_MAX_OVERSHOOT` | `15.0` | Overshoot at which torque saturates |
+| `_GRIPPER_RELEASE_HYSTERESIS` | `1.0` | Leader motion toward follower that counts as releasing |
+| `_GRIPPER_TORQUE_LIMIT_MIN` / `MAX` | `150` / `450` | Leader gripper torque cap range |
+
+## Limitations
+
+- **Gripper only** — no arm-joint haptics; the leader arm stays limp by design.
+- **Proxy sensing** — uses motor load and position, not a fingertip force sensor.
+- **Calibration** — leader and follower gripper positions must be comparable (same RANGE_0_100 normalization after calibration).
+- **Feel quality** — depends on leader gripper gearing (1/147 on SO-101); expect approximate feedback, not industrial haptics.
+
+## Tests
+
+Pure logic is covered in `tests/test_teleoperate.py` (`_gripper_feedback_targets`). Run:
+
+```bash
+pytest tests/test_teleoperate.py -q
+```

--- a/GRIPPER_FORCE_FEEDBACK.md
+++ b/GRIPPER_FORCE_FEEDBACK.md
@@ -4,6 +4,14 @@ Optional haptic feedback for SO-101 leader–follower teleoperation. When enable
 
 Arm joints stay back-drivable (torque off) at all times; only the leader gripper motor is powered when feedback is active.
 
+## Scope: LeRobot vs LeLab
+
+**[LeRobot](https://github.com/huggingface/lerobot)** supports many robot platforms (Koch, OMX, OpenArm, Unitree G1, Reachy, and more).
+
+**LeLab teleoperation** is currently implemented only for **SO leader/follower arms** (SO-100, SO-101, and SO-10X variants sharing the same `so_leader` / `so_follower` stack). Gripper force feedback is further limited to that family because it relies on STS3215 Feetech `Present_Load` sensing and the leader–follower gripper architecture.
+
+`GET /teleoperation-capabilities` reports whether gripper force feedback is available in this build. The landing-page checkbox is hidden when unsupported. `POST /move-arm` rejects `gripper_force_feedback: true` on unsupported hardware.
+
 ## Enabling in the UI
 
 1. On the **Landing** page, select a configured robot.
@@ -20,6 +28,12 @@ In dev mode, use the Vite UI at `http://localhost:8080` so you see the latest fr
 |-------|------|---------|-------------|
 | `gripper_force_feedback` | `bool` | `false` | Enable gripper-only force feedback |
 | `gripper_force_feedback_gain` | `float` | `1.0` | Resistance strength multiplier (0.1–3.0) |
+
+`GET /teleoperation-capabilities` returns:
+
+- `robot_family` — LeLab teleop stack id (currently `so_leader_follower`)
+- `robot_family_label` — human-readable hardware family
+- `gripper_force_feedback` — whether gripper haptics are supported
 
 `GET /teleoperation-status` includes:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A page will automatically open in your browser and you are ready to go.
     </tr>
     <tr>
       <td>🕹️ <b>Teleoperate</b></td>
-      <td>Move the leader, the follower mirrors it. Live joint streaming.</td>
+      <td>Move the leader, the follower mirrors it. Live joint streaming. Optional <a href="GRIPPER_FORCE_FEEDBACK.md">gripper force feedback</a> when grasping objects.</td>
     </tr>
     <tr>
       <td>📹 <b>Record</b></td>

--- a/frontend/src/components/landing/RobotConfigManager.tsx
+++ b/frontend/src/components/landing/RobotConfigManager.tsx
@@ -32,7 +32,10 @@ const RobotConfigManager: React.FC<RobotConfigManagerProps> = ({
     navigate("/calibration", { state: { robot_name: name } });
   };
 
-  const handleTeleop = async (robot: RobotRecord) => {
+  const handleTeleop = async (
+    robot: RobotRecord,
+    options: { gripperForceFeedback: boolean },
+  ) => {
     try {
       const res = await fetchWithHeaders(`${baseUrl}/move-arm`, {
         method: "POST",
@@ -42,6 +45,7 @@ const RobotConfigManager: React.FC<RobotConfigManagerProps> = ({
           follower_port: robot.follower_port,
           leader_config: robot.leader_config,
           follower_config: robot.follower_config,
+          gripper_force_feedback: options.gripperForceFeedback,
         }),
       });
       const data = await res.json();

--- a/frontend/src/components/landing/RobotConfigManager.tsx
+++ b/frontend/src/components/landing/RobotConfigManager.tsx
@@ -4,6 +4,7 @@ import { useApi } from "@/contexts/ApiContext";
 import { useToast } from "@/hooks/use-toast";
 import { RobotRecord } from "@/hooks/useRobots";
 import RobotTile from "./RobotTile";
+import { useTeleoperationCapabilities } from "@/hooks/useTeleoperationCapabilities";
 
 interface RobotConfigManagerProps {
   selectedName: string | null;
@@ -27,6 +28,7 @@ const RobotConfigManager: React.FC<RobotConfigManagerProps> = ({
   const navigate = useNavigate();
   const { baseUrl, fetchWithHeaders } = useApi();
   const { toast } = useToast();
+  const { capabilities: teleopCapabilities } = useTeleoperationCapabilities();
 
   const handleConfigure = (name: string) => {
     navigate("/calibration", { state: { robot_name: name } });
@@ -80,6 +82,7 @@ const RobotConfigManager: React.FC<RobotConfigManagerProps> = ({
       selectedName={selectedName}
       availableNames={availableNames}
       isLoading={isLoading}
+      teleopCapabilities={teleopCapabilities}
       onSelect={selectRobot}
       onCreateNew={createRobot}
       onConfigure={handleConfigure}

--- a/frontend/src/components/landing/RobotTile.tsx
+++ b/frontend/src/components/landing/RobotTile.tsx
@@ -17,6 +17,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { RobotRecord } from "@/hooks/useRobots";
+import { TeleoperationCapabilities } from "@/hooks/useTeleoperationCapabilities";
 import RobotSelector from "./RobotSelector";
 
 interface RobotTileProps {
@@ -24,6 +25,7 @@ interface RobotTileProps {
   selectedName: string | null;
   availableNames: string[];
   isLoading: boolean;
+  teleopCapabilities: TeleoperationCapabilities;
   onSelect: (name: string) => void;
   onCreateNew: (name: string) => Promise<boolean>;
   onConfigure: (name: string) => void;
@@ -36,6 +38,7 @@ const RobotTile: React.FC<RobotTileProps> = ({
   selectedName,
   availableNames,
   isLoading,
+  teleopCapabilities,
   onSelect,
   onCreateNew,
   onConfigure,
@@ -46,6 +49,7 @@ const RobotTile: React.FC<RobotTileProps> = ({
   const [gripperForceFeedback, setGripperForceFeedback] = useState(false);
   const status = robot ? (robot.is_clean ? "Ready" : "Needs configuration") : null;
   const teleopDisabled = !robot || !robot.is_clean;
+  const gripperFeedbackAvailable = teleopCapabilities.gripper_force_feedback;
 
   return (
     <div className="bg-gray-800 rounded-lg border border-gray-700 p-3 flex flex-col gap-2 relative">
@@ -104,29 +108,31 @@ const RobotTile: React.FC<RobotTileProps> = ({
 
       {robot && (
         <>
-          <div className="flex items-start gap-3">
-            <Checkbox
-              id={`gripper-force-feedback-${robot.name}`}
-              checked={gripperForceFeedback}
-              onCheckedChange={(value) => setGripperForceFeedback(value === true)}
-              disabled={teleopDisabled}
-              className="mt-0.5 border-gray-500 data-[state=checked]:bg-yellow-500 data-[state=checked]:border-yellow-500"
-            />
-            <div className="space-y-1">
-              <Label
-                htmlFor={`gripper-force-feedback-${robot.name}`}
-                className={`text-sm font-medium cursor-pointer ${
-                  teleopDisabled ? "text-gray-500" : "text-gray-200"
-                }`}
-              >
-                Gripper force feedback
-              </Label>
-              <p className="text-xs text-gray-500">
-                Feel resistance on the leader gripper when the follower grasps
-                something.
-              </p>
+          {gripperFeedbackAvailable && (
+            <div className="flex items-start gap-3">
+              <Checkbox
+                id={`gripper-force-feedback-${robot.name}`}
+                checked={gripperForceFeedback}
+                onCheckedChange={(value) => setGripperForceFeedback(value === true)}
+                disabled={teleopDisabled}
+                className="mt-0.5 border-gray-500 data-[state=checked]:bg-yellow-500 data-[state=checked]:border-yellow-500"
+              />
+              <div className="space-y-1">
+                <Label
+                  htmlFor={`gripper-force-feedback-${robot.name}`}
+                  className={`text-sm font-medium cursor-pointer ${
+                    teleopDisabled ? "text-gray-500" : "text-gray-200"
+                  }`}
+                >
+                  Gripper force feedback
+                </Label>
+                <p className="text-xs text-gray-500">
+                  {teleopCapabilities.robot_family_label}: feel resistance on the
+                  leader gripper when the follower grasps something.
+                </p>
+              </div>
             </div>
-          </div>
+          )}
           <Tooltip>
             <TooltipTrigger asChild>
               <div className="w-full">

--- a/frontend/src/components/landing/RobotTile.tsx
+++ b/frontend/src/components/landing/RobotTile.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { Settings, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 import {
   Tooltip,
   TooltipContent,
@@ -25,7 +27,7 @@ interface RobotTileProps {
   onSelect: (name: string) => void;
   onCreateNew: (name: string) => Promise<boolean>;
   onConfigure: (name: string) => void;
-  onTeleop: (robot: RobotRecord) => void;
+  onTeleop: (robot: RobotRecord, options: { gripperForceFeedback: boolean }) => void;
   onDelete: (name: string) => void;
 }
 
@@ -41,6 +43,7 @@ const RobotTile: React.FC<RobotTileProps> = ({
   onDelete,
 }) => {
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [gripperForceFeedback, setGripperForceFeedback] = useState(false);
   const status = robot ? (robot.is_clean ? "Ready" : "Needs configuration") : null;
   const teleopDisabled = !robot || !robot.is_clean;
 
@@ -100,26 +103,51 @@ const RobotTile: React.FC<RobotTileProps> = ({
       </div>
 
       {robot && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="w-full">
-              <Button
-                onClick={() => onTeleop(robot)}
-                disabled={teleopDisabled}
-                className={`w-full ${
-                  teleopDisabled
-                    ? "bg-red-500/30 hover:bg-red-500/30 text-red-200 cursor-not-allowed"
-                    : "bg-yellow-500 hover:bg-yellow-600 text-white"
+        <>
+          <div className="flex items-start gap-3">
+            <Checkbox
+              id={`gripper-force-feedback-${robot.name}`}
+              checked={gripperForceFeedback}
+              onCheckedChange={(value) => setGripperForceFeedback(value === true)}
+              disabled={teleopDisabled}
+              className="mt-0.5 border-gray-500 data-[state=checked]:bg-yellow-500 data-[state=checked]:border-yellow-500"
+            />
+            <div className="space-y-1">
+              <Label
+                htmlFor={`gripper-force-feedback-${robot.name}`}
+                className={`text-sm font-medium cursor-pointer ${
+                  teleopDisabled ? "text-gray-500" : "text-gray-200"
                 }`}
               >
-                Teleoperation
-              </Button>
+                Gripper force feedback
+              </Label>
+              <p className="text-xs text-gray-500">
+                Feel resistance on the leader gripper when the follower grasps
+                something.
+              </p>
             </div>
-          </TooltipTrigger>
-          {teleopDisabled && (
-            <TooltipContent>Configure the robot first.</TooltipContent>
-          )}
-        </Tooltip>
+          </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="w-full">
+                <Button
+                  onClick={() => onTeleop(robot, { gripperForceFeedback })}
+                  disabled={teleopDisabled}
+                  className={`w-full ${
+                    teleopDisabled
+                      ? "bg-red-500/30 hover:bg-red-500/30 text-red-200 cursor-not-allowed"
+                      : "bg-yellow-500 hover:bg-yellow-600 text-white"
+                  }`}
+                >
+                  Teleoperation
+                </Button>
+              </div>
+            </TooltipTrigger>
+            {teleopDisabled && (
+              <TooltipContent>Configure the robot first.</TooltipContent>
+            )}
+          </Tooltip>
+        </>
       )}
 
       {robot && (

--- a/frontend/src/hooks/useTeleoperationCapabilities.ts
+++ b/frontend/src/hooks/useTeleoperationCapabilities.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { useApi } from "@/contexts/ApiContext";
+
+export interface TeleoperationCapabilities {
+  robot_family: string;
+  robot_family_label: string;
+  gripper_force_feedback: boolean;
+}
+
+const DEFAULT_CAPABILITIES: TeleoperationCapabilities = {
+  robot_family: "so_leader_follower",
+  robot_family_label: "SO-100 / SO-101 leader–follower",
+  gripper_force_feedback: false,
+};
+
+export const useTeleoperationCapabilities = () => {
+  const { baseUrl, fetchWithHeaders } = useApi();
+  const [capabilities, setCapabilities] =
+    useState<TeleoperationCapabilities>(DEFAULT_CAPABILITIES);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const res = await fetchWithHeaders(`${baseUrl}/teleoperation-capabilities`);
+        const data = await res.json();
+        if (cancelled) return;
+        setCapabilities({
+          robot_family: data.robot_family ?? DEFAULT_CAPABILITIES.robot_family,
+          robot_family_label:
+            data.robot_family_label ?? DEFAULT_CAPABILITIES.robot_family_label,
+          gripper_force_feedback: Boolean(data.gripper_force_feedback),
+        });
+      } catch {
+        if (!cancelled) setCapabilities(DEFAULT_CAPABILITIES);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [baseUrl, fetchWithHeaders]);
+
+  return { capabilities, isLoading };
+};

--- a/frontend/src/pages/Teleoperation.tsx
+++ b/frontend/src/pages/Teleoperation.tsx
@@ -5,6 +5,8 @@ import TeleopCameraPanel from "@/components/control/TeleopCameraPanel";
 import { useToast } from "@/hooks/use-toast";
 import { useApi } from "@/contexts/ApiContext";
 
+const STATUS_POLL_MS = 2000;
+
 const TeleoperationPage = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -42,8 +44,11 @@ const TeleoperationPage = () => {
   //     and stashes a flag the next page reads to confirm the clean disconnect.
   //     It uses a bare fetch (no JSON Content-Type) so the request stays a CORS
   //     "simple request" and isn't dropped to a preflight mid-unload.
+  //   - pagehide with `persisted` (bfcache) is ignored so backgrounding the
+  //     tab does not kill an active session.
   useEffect(() => {
-    const handlePageHide = () => {
+    const handlePageHide = (event: PageTransitionEvent) => {
+      if (event.persisted) return;
       try {
         sessionStorage.setItem("lelab:teleop-stopped", "1");
       } catch {
@@ -61,6 +66,41 @@ const TeleoperationPage = () => {
       stopTeleoperation();
     };
   }, [baseUrl, stopTeleoperation]);
+
+  // If the backend worker dies (serial glitch, unplug, etc.) while this page
+  // is still open, surface it instead of leaving the user moving a dead leader.
+  useEffect(() => {
+    let cancelled = false;
+
+    const pollStatus = async () => {
+      try {
+        const res = await fetchWithHeaders(`${baseUrl}/teleoperation-status`);
+        const data = await res.json();
+        if (cancelled || stoppedRef.current) return;
+        if (data?.teleoperation_active) return;
+
+        stoppedRef.current = true;
+        const reason =
+          typeof data?.stop_reason === "string" && data.stop_reason
+            ? data.stop_reason
+            : "The teleoperation session ended unexpectedly.";
+        toast({
+          title: "Teleoperation ended",
+          description: reason,
+          variant: "destructive",
+        });
+        navigate("/");
+      } catch {
+        /* best-effort; keep polling */
+      }
+    };
+
+    const interval = setInterval(pollStatus, STATUS_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [baseUrl, fetchWithHeaders, navigate, toast]);
 
   const handleGoBack = async () => {
     await stopTeleoperation();

--- a/lelab/server.py
+++ b/lelab/server.py
@@ -75,6 +75,7 @@ from .teleoperate import (
     handle_get_joint_positions,
     handle_start_teleoperation,
     handle_stop_teleoperation,
+    handle_teleoperation_capabilities,
     handle_teleoperation_status,
 )
 
@@ -318,6 +319,12 @@ def stop_teleoperation():
 def teleoperation_status():
     """Get the current teleoperation status"""
     return handle_teleoperation_status()
+
+
+@app.get("/teleoperation-capabilities")
+def teleoperation_capabilities():
+    """Report teleoperation features supported by this LeLab build."""
+    return handle_teleoperation_capabilities()
 
 
 @app.get("/joint-positions")

--- a/lelab/teleoperate.py
+++ b/lelab/teleoperate.py
@@ -18,7 +18,7 @@ import threading
 import time
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from lerobot.robots.so_follower import SO101Follower, SO101FollowerConfig
 from lerobot.teleoperators.so_leader import SO101Leader, SO101LeaderConfig
@@ -47,11 +47,29 @@ _SO101_URDF_CORRECTIONS = {
     "elbow_flex": (+1, 1029),
 }
 
+_GRIPPER_MOTOR = "gripper"
+# Present_Load magnitude (after bus decode) below which we assume no grasp.
+_GRIPPER_LOAD_DEADBAND = 20.0
+# Leader must be this far past the follower (RANGE_0_100) before resistance kicks in.
+_GRIPPER_POSITION_MARGIN = 2.0
+# Overshoot at which resistance reaches full strength.
+_GRIPPER_MAX_OVERSHOOT = 15.0
+# Leader moving back toward the follower by this much is treated as releasing.
+_GRIPPER_RELEASE_HYSTERESIS = 1.0
+_GRIPPER_TORQUE_LIMIT_MIN = 150
+_GRIPPER_TORQUE_LIMIT_MAX = 450
+# Serial glitches are common; only tear down after sustained failures.
+_MAX_CONSECUTIVE_LOOP_ERRORS = 50
+_LOOP_ERROR_BACKOFF_S = 0.01
+
 # Global variables for teleoperation state
 teleoperation_active = False
 teleoperation_thread: threading.Thread | None = None
 current_robot = None
 current_teleop = None
+gripper_force_feedback_active = False
+teleoperation_stop_reason: str | None = None
+_last_leader_gripper_pos: float | None = None
 # Guards the start path; the worker owns disconnect so stop() does not race.
 _state_lock = threading.Lock()
 
@@ -61,6 +79,8 @@ class TeleoperateRequest(BaseModel):
     follower_port: str
     leader_config: str
     follower_config: str
+    gripper_force_feedback: bool = False
+    gripper_force_feedback_gain: float = Field(default=1.0, ge=0.1, le=3.0)
 
 
 def get_joint_positions_from_robot(robot) -> dict[str, float]:
@@ -123,6 +143,103 @@ def get_joint_positions_from_robot(robot) -> dict[str, float]:
         return dict.fromkeys(motor_to_urdf_mapping.values(), 0.0)
 
 
+def _gripper_feedback_targets(
+    follower_pos: float,
+    leader_pos: float,
+    follower_load: float,
+    gain: float,
+    prev_leader_pos: float | None,
+) -> tuple[float, int, bool]:
+    """Map follower grasp state to a leader goal and torque limit.
+
+    Resistance only applies when the follower is loaded (grasping something) and
+    the leader is being squeezed *past* the follower's current gripper position.
+    Releasing — leader moving back toward the follower — disables feedback.
+    """
+    load = abs(follower_load)
+    diff = leader_pos - follower_pos
+
+    if prev_leader_pos is not None:
+        prev_diff = prev_leader_pos - follower_pos
+        if abs(diff) < abs(prev_diff) - _GRIPPER_RELEASE_HYSTERESIS:
+            return leader_pos, _GRIPPER_TORQUE_LIMIT_MIN, False
+
+    if load < _GRIPPER_LOAD_DEADBAND:
+        return leader_pos, _GRIPPER_TORQUE_LIMIT_MIN, False
+
+    overshoot = abs(diff)
+    if overshoot <= _GRIPPER_POSITION_MARGIN:
+        return leader_pos, _GRIPPER_TORQUE_LIMIT_MIN, False
+
+    span = max(_GRIPPER_MAX_OVERSHOOT - _GRIPPER_POSITION_MARGIN, 1.0)
+    overshoot_frac = min(1.0, (overshoot - _GRIPPER_POSITION_MARGIN) / span)
+    # Virtual wall at the follower's achieved grip position.
+    goal = min(100.0, max(0.0, follower_pos))
+    torque_limit = int(
+        _GRIPPER_TORQUE_LIMIT_MIN
+        + overshoot_frac * gain * (_GRIPPER_TORQUE_LIMIT_MAX - _GRIPPER_TORQUE_LIMIT_MIN)
+    )
+    torque_limit = min(_GRIPPER_TORQUE_LIMIT_MAX, max(_GRIPPER_TORQUE_LIMIT_MIN, torque_limit))
+    return goal, torque_limit, True
+
+
+def _reset_gripper_force_feedback_state() -> None:
+    global _last_leader_gripper_pos
+    _last_leader_gripper_pos = None
+
+
+def _setup_leader_gripper_force_feedback(teleop_device) -> None:
+    """Tune the leader gripper for compliant resistance while arm joints stay limp."""
+    bus = teleop_device.bus
+    bus.write("P_Coefficient", _GRIPPER_MOTOR, 8)
+    bus.write("I_Coefficient", _GRIPPER_MOTOR, 0)
+    bus.write("D_Coefficient", _GRIPPER_MOTOR, 20)
+    bus.disable_torque(motors=[_GRIPPER_MOTOR])
+
+
+def _apply_gripper_force_feedback(robot, teleop_device, gain: float) -> None:
+    """Resist closing the leader gripper past the follower's grasp position."""
+    global _last_leader_gripper_pos
+
+    bus_leader = teleop_device.bus
+    bus_follower = robot.bus
+    try:
+        follower_load = bus_follower.sync_read("Present_Load", [_GRIPPER_MOTOR])[_GRIPPER_MOTOR]
+        follower_pos = bus_follower.sync_read("Present_Position", [_GRIPPER_MOTOR])[_GRIPPER_MOTOR]
+        leader_present = bus_leader.sync_read("Present_Position", [_GRIPPER_MOTOR])[_GRIPPER_MOTOR]
+    except Exception as e:
+        logger.debug("Gripper force feedback read failed: %s", e)
+        return
+
+    goal, torque_limit, active = _gripper_feedback_targets(
+        follower_pos,
+        leader_present,
+        follower_load,
+        gain,
+        _last_leader_gripper_pos,
+    )
+    _last_leader_gripper_pos = leader_present
+    try:
+        if not active:
+            bus_leader.disable_torque(motors=[_GRIPPER_MOTOR])
+            return
+
+        bus_leader.enable_torque(motors=[_GRIPPER_MOTOR])
+        bus_leader.write("Torque_Limit", _GRIPPER_MOTOR, torque_limit)
+        bus_leader.sync_write("Goal_Position", {_GRIPPER_MOTOR: goal})
+    except Exception as e:
+        logger.debug("Gripper force feedback write failed: %s", e)
+
+
+def _teardown_leader_gripper_force_feedback(teleop_device) -> None:
+    """Release leader gripper torque before disconnect."""
+    _reset_gripper_force_feedback_state()
+    try:
+        teleop_device.bus.disable_torque(motors=[_GRIPPER_MOTOR])
+    except Exception as e:
+        logger.debug("Gripper force feedback teardown failed: %s", e)
+
+
 def _safe_disconnect(device) -> None:
     """Disconnect a robot/teleop device, swallowing (but logging) any error.
 
@@ -140,7 +257,13 @@ def handle_start_teleoperation(request: TeleoperateRequest, websocket_manager=No
     dying silently in the worker thread while the API has already claimed
     success. Only the teleoperation loop runs in the background thread.
     """
-    global teleoperation_active, teleoperation_thread, current_robot, current_teleop
+    global \
+        teleoperation_active, \
+        teleoperation_thread, \
+        current_robot, \
+        current_teleop, \
+        gripper_force_feedback_active, \
+        teleoperation_stop_reason
 
     from . import record as _record, rollout as _rollout
 
@@ -152,6 +275,7 @@ def handle_start_teleoperation(request: TeleoperateRequest, websocket_manager=No
         if _rollout.inference_active:
             return {"success": False, "message": "Inference is currently active. Stop it first."}
         teleoperation_active = True
+        teleoperation_stop_reason = None
 
     robot = None
     teleop_device = None
@@ -214,24 +338,56 @@ def handle_start_teleoperation(request: TeleoperateRequest, websocket_manager=No
             cam.connect()
         robot.configure()
         teleop_device.configure()
+        if request.gripper_force_feedback:
+            _setup_leader_gripper_force_feedback(teleop_device)
+            _reset_gripper_force_feedback_state()
         logger.info("Successfully connected to both devices")
 
         current_robot = robot
         current_teleop = teleop_device
+        gripper_force_feedback_active = request.gripper_force_feedback
+        feedback_gain = request.gripper_force_feedback_gain
 
         # Stream the arms in the background; the worker owns disconnect so stop()
         # does not race the serial bus from the request thread.
         def teleoperation_worker():
-            global teleoperation_active, current_robot, current_teleop
+            global \
+                teleoperation_active, \
+                current_robot, \
+                current_teleop, \
+                gripper_force_feedback_active, \
+                teleoperation_stop_reason
 
             logger.info("Starting teleoperation loop...")
+            consecutive_errors = 0
             try:
                 last_broadcast_time = 0
                 broadcast_interval = 0.05  # 20 FPS
 
                 while teleoperation_active:
-                    action = teleop_device.get_action()
-                    robot.send_action(action)
+                    try:
+                        action = teleop_device.get_action()
+                        robot.send_action(action)
+                        if request.gripper_force_feedback:
+                            _apply_gripper_force_feedback(robot, teleop_device, feedback_gain)
+                        consecutive_errors = 0
+                    except Exception as e:
+                        consecutive_errors += 1
+                        logger.warning(
+                            "Teleoperation loop error (%d/%d): %s",
+                            consecutive_errors,
+                            _MAX_CONSECUTIVE_LOOP_ERRORS,
+                            e,
+                        )
+                        if consecutive_errors >= _MAX_CONSECUTIVE_LOOP_ERRORS:
+                            teleoperation_stop_reason = (
+                                f"Stopped after {_MAX_CONSECUTIVE_LOOP_ERRORS} consecutive "
+                                f"communication errors: {e}"
+                            )
+                            logger.error(teleoperation_stop_reason, exc_info=True)
+                            break
+                        time.sleep(_LOOP_ERROR_BACKOFF_S)
+                        continue
 
                     current_time = time.time()
                     if current_time - last_broadcast_time >= broadcast_interval:
@@ -250,14 +406,18 @@ def handle_start_teleoperation(request: TeleoperateRequest, websocket_manager=No
 
                     time.sleep(0.001)
             except Exception as e:
-                logger.error(f"Error during teleoperation loop: {e}")
+                teleoperation_stop_reason = f"Unexpected teleoperation error: {e}"
+                logger.error(teleoperation_stop_reason, exc_info=True)
             finally:
+                if request.gripper_force_feedback:
+                    _teardown_leader_gripper_force_feedback(teleop_device)
                 _safe_disconnect(robot)
                 _safe_disconnect(teleop_device)
                 logger.info("Teleoperation stopped")
                 teleoperation_active = False
                 current_robot = None
                 current_teleop = None
+                gripper_force_feedback_active = False
 
         teleoperation_thread = threading.Thread(
             target=teleoperation_worker, name="teleoperation-worker", daemon=True
@@ -269,6 +429,7 @@ def handle_start_teleoperation(request: TeleoperateRequest, websocket_manager=No
             "message": "Teleoperation started successfully",
             "leader_port": request.leader_port,
             "follower_port": request.follower_port,
+            "gripper_force_feedback": request.gripper_force_feedback,
         }
 
     except Exception as e:
@@ -279,6 +440,7 @@ def handle_start_teleoperation(request: TeleoperateRequest, websocket_manager=No
         teleoperation_active = False
         current_robot = None
         current_teleop = None
+        gripper_force_feedback_active = False
         logger.error(f"Failed to start teleoperation: {e}")
         # str(e) is already a user-facing message for the connection failures
         # raised above; the toast title supplies the "error starting" context.
@@ -292,12 +454,13 @@ def handle_stop_teleoperation() -> dict[str, Any]:
     exit. The worker owns the disconnect call, so this avoids racing the
     serial bus from the request thread.
     """
-    global teleoperation_active, teleoperation_thread
+    global teleoperation_active, teleoperation_thread, teleoperation_stop_reason
 
     if not teleoperation_active:
         return {"success": False, "message": "No teleoperation session is active"}
 
     logger.info("Stop teleoperation triggered from web interface")
+    teleoperation_stop_reason = "Stopped by user"
     teleoperation_active = False
 
     worker = teleoperation_thread
@@ -314,6 +477,8 @@ def handle_teleoperation_status() -> dict[str, Any]:
     """Handle teleoperation status request"""
     return {
         "teleoperation_active": teleoperation_active,
+        "gripper_force_feedback": gripper_force_feedback_active,
+        "stop_reason": teleoperation_stop_reason,
         "available_controls": {
             "stop_teleoperation": teleoperation_active,
         },

--- a/lelab/teleoperate.py
+++ b/lelab/teleoperate.py
@@ -28,6 +28,11 @@ from .utils.devices import safe_disconnect_device
 
 logger = logging.getLogger(__name__)
 
+# LeLab teleoperation is implemented for SO leader/follower arms only (SO-100/101/10X).
+# LeRobot itself supports many other robot platforms; this constant gates SO-specific
+# features until LeLab grows a per-robot hardware model.
+LELAB_TELEOP_ROBOT_FAMILY = "so_leader_follower"
+
 # sts3215 motor resolution; lerobot's _normalize uses (resolution - 1).
 _STS3215_MAX_RES = 4095
 
@@ -81,6 +86,21 @@ class TeleoperateRequest(BaseModel):
     follower_config: str
     gripper_force_feedback: bool = False
     gripper_force_feedback_gain: float = Field(default=1.0, ge=0.1, le=3.0)
+
+
+def gripper_force_feedback_supported() -> bool:
+    """Whether the current LeLab teleop stack supports gripper haptics."""
+    return LELAB_TELEOP_ROBOT_FAMILY == "so_leader_follower"
+
+
+def handle_teleoperation_capabilities() -> dict[str, Any]:
+    """Report which teleoperation features apply to LeLab's configured hardware."""
+    return {
+        "robot_family": LELAB_TELEOP_ROBOT_FAMILY,
+        "robot_family_label": "SO-100 / SO-101 leader–follower",
+        "gripper_force_feedback": gripper_force_feedback_supported(),
+        "message": "Teleoperation capabilities retrieved successfully",
+    }
 
 
 def get_joint_positions_from_robot(robot) -> dict[str, float]:
@@ -266,6 +286,15 @@ def handle_start_teleoperation(request: TeleoperateRequest, websocket_manager=No
         teleoperation_stop_reason
 
     from . import record as _record, rollout as _rollout
+
+    if request.gripper_force_feedback and not gripper_force_feedback_supported():
+        return {
+            "success": False,
+            "message": (
+                "Gripper force feedback is only available for SO-100 / SO-101 "
+                "leader–follower arms."
+            ),
+        }
 
     with _state_lock:
         if teleoperation_active:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -29,6 +29,7 @@ REQUIRED_PATHS = {
     "/move-arm",
     "/stop-teleoperation",
     "/teleoperation-status",
+    "/teleoperation-capabilities",
     "/joint-positions",
     "/start-recording",
     "/stop-recording",

--- a/tests/test_teleoperate.py
+++ b/tests/test_teleoperate.py
@@ -92,6 +92,36 @@ def test_gripper_feedback_targets_scales_with_gain() -> None:
     assert high_gain_torque > low_gain_torque
 
 
+def test_handle_teleoperation_capabilities_reports_so_family() -> None:
+    from lelab.teleoperate import (
+        gripper_force_feedback_supported,
+        handle_teleoperation_capabilities,
+    )
+
+    caps = handle_teleoperation_capabilities()
+    assert caps["robot_family"] == "so_leader_follower"
+    assert caps["gripper_force_feedback"] is gripper_force_feedback_supported()
+
+
+def test_start_teleoperation_rejects_force_feedback_when_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import lelab.teleoperate as teleop
+
+    monkeypatch.setattr(teleop, "gripper_force_feedback_supported", lambda: False)
+
+    request = teleop.TeleoperateRequest(
+        leader_port="COM1",
+        follower_port="COM2",
+        leader_config="leader",
+        follower_config="follower",
+        gripper_force_feedback=True,
+    )
+    result = teleop.handle_start_teleoperation(request)
+    assert result["success"] is False
+    assert "SO-100" in result["message"]
+
+
 def test_handle_teleoperation_status_returns_dict() -> None:
     from lelab.teleoperate import handle_teleoperation_status
 

--- a/tests/test_teleoperate.py
+++ b/tests/test_teleoperate.py
@@ -27,11 +27,77 @@ def test_teleoperate_request_rejects_missing_fields() -> None:
         TeleoperateRequest()
 
 
+def test_teleoperate_request_defaults_force_feedback_off() -> None:
+    from lelab.teleoperate import TeleoperateRequest
+
+    request = TeleoperateRequest(
+        leader_port="COM1",
+        follower_port="COM2",
+        leader_config="leader",
+        follower_config="follower",
+    )
+    assert request.gripper_force_feedback is False
+    assert request.gripper_force_feedback_gain == 1.0
+
+
+def test_gripper_feedback_targets_inactive_without_load() -> None:
+    from lelab.teleoperate import _gripper_feedback_targets
+
+    goal, torque_limit, active = _gripper_feedback_targets(50.0, 55.0, 5.0, 1.0, None)
+    assert active is False
+    assert goal == 55.0
+    assert torque_limit == 150
+
+
+def test_gripper_feedback_targets_inactive_when_leader_not_past_follower() -> None:
+    from lelab.teleoperate import _gripper_feedback_targets
+
+    goal, _, active = _gripper_feedback_targets(50.0, 50.5, 200.0, 1.0, None)
+    assert active is False
+    assert goal == 50.5
+
+
+def test_gripper_feedback_targets_wall_at_follower_position() -> None:
+    from lelab.teleoperate import _gripper_feedback_targets
+
+    goal, torque_limit, active = _gripper_feedback_targets(50.0, 60.0, 200.0, 1.0, None)
+    assert active is True
+    assert goal == 50.0
+    assert torque_limit > 150
+
+
+def test_gripper_feedback_targets_inactive_when_releasing() -> None:
+    from lelab.teleoperate import _gripper_feedback_targets
+
+    goal, _, active = _gripper_feedback_targets(50.0, 58.0, 200.0, 1.0, 60.0)
+    assert active is False
+    assert goal == 58.0
+
+
+def test_gripper_feedback_targets_wall_when_leader_below_follower() -> None:
+    """Works regardless of whether closing increases or decreases position."""
+    from lelab.teleoperate import _gripper_feedback_targets
+
+    goal, torque_limit, active = _gripper_feedback_targets(50.0, 40.0, 200.0, 1.0, None)
+    assert active is True
+    assert goal == 50.0
+    assert torque_limit > 150
+
+
+def test_gripper_feedback_targets_scales_with_gain() -> None:
+    from lelab.teleoperate import _gripper_feedback_targets
+
+    _, low_gain_torque, _ = _gripper_feedback_targets(50.0, 65.0, 200.0, 0.5, None)
+    _, high_gain_torque, _ = _gripper_feedback_targets(50.0, 65.0, 200.0, 2.0, None)
+    assert high_gain_torque > low_gain_torque
+
+
 def test_handle_teleoperation_status_returns_dict() -> None:
     from lelab.teleoperate import handle_teleoperation_status
 
     result = handle_teleoperation_status()
     assert isinstance(result, dict)
+    assert "stop_reason" in result
 
 
 def test_handle_get_joint_positions_returns_dict_when_idle() -> None:


### PR DESCRIPTION
Adds optional **gripper-only force feedback** for SO-101 teleoperation: when the follower grasps an object, the leader gripper resists squeezing past the follower's achieved position (virtual wall), with no feedback while releasing.
- Exposes a **Gripper force feedback** checkbox on the landing page robot tile and optional `gripper_force_feedback` / `gripper_force_feedback_gain` fields on `POST /move-arm`.