### PR TITLE
fix(devices): force-release camera/serial in recording and calibration teardown

### DIFF
--- a/lelab/calibrate.py
+++ b/lelab/calibrate.py
@@ -38,6 +38,8 @@ from lerobot.teleoperators import (
 )
 from lerobot.utils.utils import init_logging
 
+from .utils.devices import safe_disconnect_device
+
 logger = logging.getLogger(__name__)
 
 
@@ -523,14 +525,16 @@ class CalibrationManager:
         self._update_status(calibration_active=False, status=status, message=message)
 
     def _cleanup_device(self):
-        """Clean up device connection"""
-        try:
-            if self.device:
-                logger.info("Disconnecting device...")
-                self.device.disconnect()
-                self.device = None
-        except Exception as e:
-            logger.error(f"Error disconnecting device: {e}")
+        """Clean up device connection.
+
+        Uses safe_disconnect_device so a failed disconnect (flaky USB/serial)
+        force-releases the port/cameras instead of leaving the device busy and
+        blocking the next calibration/teleop/record run.
+        """
+        if self.device:
+            logger.info("Disconnecting device...")
+            safe_disconnect_device(self.device, logger, context="calibration cleanup")
+            self.device = None
 
 
 # Global calibration manager instance

--- a/lelab/record.py
+++ b/lelab/record.py
@@ -31,6 +31,7 @@ from lerobot.scripts.lerobot_record import RecordConfig
 from lerobot.teleoperators.so_leader import SO101LeaderConfig
 
 from .utils.config import setup_calibration_files, with_lelab_tag
+from .utils.devices import safe_disconnect_device
 
 logger = logging.getLogger(__name__)
 
@@ -862,9 +863,12 @@ def record_with_web_events(cfg: RecordConfig, web_events: dict) -> LeRobotDatase
         log_say("Stop recording", cfg.play_sounds, blocking=True)
 
     finally:
-        robot.disconnect()
+        # safe_disconnect_device force-releases the serial port / cameras if a
+        # normal disconnect fails, so a flaky teardown can't leave the device
+        # busy and block the next recording session (see issue #50).
+        safe_disconnect_device(robot, logger, context="recording cleanup")
         if teleop:
-            teleop.disconnect()
+            safe_disconnect_device(teleop, logger, context="recording cleanup")
 
     if cfg.dataset.push_to_hub:
         dataset.push_to_hub(tags=cfg.dataset.tags, private=cfg.dataset.private)

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -72,3 +72,32 @@ def test_calibration_manager_rejects_double_start_via_message() -> None:
     )
     assert result.get("success") is False
     assert "already" in result.get("message", "").lower()
+
+
+def test_cleanup_device_force_releases_and_clears_when_disconnect_fails() -> None:
+    """A failed device.disconnect() must still force-close the port and clear the
+    device handle — otherwise the COM port stays busy and blocks the next run."""
+    from lelab.calibrate import CalibrationManager
+
+    class PortHandler:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def closePort(self) -> None:  # noqa: N802 - mirrors LeRobot port handler API
+            self.closed = True
+
+    class Device:
+        def __init__(self) -> None:
+            self.bus = type("Bus", (), {"port_handler": PortHandler()})()
+
+        def disconnect(self) -> None:
+            raise RuntimeError("Failed to write 'Torque_Enable' on id_=6")
+
+    mgr = CalibrationManager()
+    device = Device()
+    mgr.device = device
+
+    mgr._cleanup_device()
+
+    assert device.bus.port_handler.closed is True  # force-released despite failure
+    assert mgr.device is None  # handle cleared so a new calibration can start


### PR DESCRIPTION
### Problem
When a device `disconnect()` fails during recording or calibration teardown 
(a flaky USB camera or serial port; an issue common on Windows), the underlying 
handle can stay open. That keeps the camera/COM port busy and blocks the next 
session from acquiring it. This is the failure mode behind issue #50 :
recording hangs on "PREPARING SESSION" with the backend logging 
*"Waiting for camera resources to be released."*

### Context
`safe_disconnect_device()` (`lelab/utils/devices.py`) was added to force-close the serial port + cameras
when a normal disconnect throws but it was wired only into teleoperation's teardown. Its own commit
noted "other call sites (calibration, recording) can adopt the same helper in follow-ups,"
and in #50 Nicolas noted the recording path still needs this treatment. This PR completes that rollout.

### Change
- `record.py` : the recording-session `finally` now calls `safe_disconnect_device(robot, …)` (and the
  teleop device) instead of a bare `disconnect()`, so a flaky teardown force-releases the device.
- `calibrate.py` : `_cleanup_device()` now force-releases and always clears `self.device`. The old
  code set `self.device = None` *inside* the `try` after `disconnect()`, so a failed disconnect left both
  the port open and the handle set : blocking the next calibration. Now both are always handled.

### Testing
- **Hardware-confirmed on Windows 11 (SO-101 + USB `wrist_cam`, lerobot 0.6.0).** Before (on `main`): a
  recording that ends without a clean disconnect leaks the camera; the teardown logs no
  `OpenCVCamera(0) disconnected`, and the next recording dies with 
`OpenCVCamera(0) read failed
  (status=False)` / "camera resource conflict". After (this branch): the
 teardown force-releases the camera and the next recording acquires it normally.
- New `test_cleanup_device_force_releases_and_clears_when_disconnect_fails`; asserts that when the
  device's `disconnect()` raises, calibration cleanup still force-closes the port and clears the handle.
- Full suite: 186 passed, 2 failed; the 2 failures (`test_pid_alive_returns_false_for_unlikely_pid`,
  `test_list_imported_local_checkpoints_tree`, both in `test_jobs.py`) are pre-existing on `main`
  (confirmed by re-running them with this change stashed) and unrelated to this PR.
- pre-commit green (ruff, ruff-format, mypy, bandit, typos, pyupgrade).

### Notes / scope
- This applies the force-release the maintainer identified as missing on the recording path; whether it
  fully resolves #50 for the reporter (their report also mentions a COM-port conflict after visiting
  Teleoperation first) is worth confirming; hence "Addresses" not "Fixes."
- Deliberately tight: this only wires in the existing helper. The deeper calibration stop/restart threading
  race (worker still alive during cleanup; `start_calibration` not checking `thread.is_alive()`) is a
  separate, more opinionated change and is left out of this PR.
- Source-only; no frontend changes