### PR TITLE
Add dataset resume, demo mode, and stability fixes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import Calibration from "@/pages/Calibration";
 import Recording from "@/pages/Recording";
 import Training from "@/pages/Training";
 import Inference from "@/pages/Inference";
+import Demo from "@/pages/Demo";
 import EditDataset from "@/pages/EditDataset";
 import Upload from "@/pages/Upload";
 
@@ -44,6 +45,7 @@ function App() {
                         <Route path="/training" element={<Training />} />
                         <Route path="/training/:jobId" element={<Training />} />
                         <Route path="/inference" element={<Inference />} />
+                        <Route path="/demo" element={<Demo />} />
                         <Route path="/calibration" element={<Calibration />} />
                         <Route path="/edit-dataset" element={<EditDataset />} />
 

--- a/frontend/src/components/landing/DatasetPicker.tsx
+++ b/frontend/src/components/landing/DatasetPicker.tsx
@@ -14,11 +14,24 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { DatasetItem } from "@/lib/replayApi";
+import { getEpisodeTarget } from "@/lib/episodeTargets";
+
+function relativeDate(iso: string | null): string | null {
+  if (!iso) return null;
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const days = Math.floor(diffMs / 86_400_000);
+  if (days <= 0) return "today";
+  if (days === 1) return "yesterday";
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return months < 12 ? `${months}mo ago` : `${Math.floor(months / 12)}y ago`;
+}
 
 interface DatasetPickerProps {
   datasets: DatasetItem[];
   loading: boolean;
   onPickExisting: (item: DatasetItem) => void;
+  onResumeExisting?: (item: DatasetItem) => void;
   onCreateNew: (name: string) => void;
   onOpenCustom: (repoId: string) => void;
   children: React.ReactNode;
@@ -31,6 +44,7 @@ const DatasetPicker: React.FC<DatasetPickerProps> = ({
   datasets,
   loading,
   onPickExisting,
+  onResumeExisting,
   onCreateNew,
   onOpenCustom,
   children,
@@ -87,22 +101,69 @@ const DatasetPicker: React.FC<DatasetPickerProps> = ({
     reset();
   };
 
-  const renderItem = (d: DatasetItem) => (
+  const renderItem = (d: DatasetItem) => {
+    const target = getEpisodeTarget(d.repo_id);
+    const detailParts: string[] = [];
+    if (d.num_episodes != null) {
+      detailParts.push(
+        target
+          ? `${d.num_episodes}/${target} episodes`
+          : `${d.num_episodes} episodes`,
+      );
+    }
+    const rel = relativeDate(d.last_modified);
+    if (rel) detailParts.push(rel);
+    const progress =
+      target && d.num_episodes != null
+        ? Math.min(100, Math.round((d.num_episodes / target) * 100))
+        : null;
+    return (
     <CommandItem
       key={d.repo_id}
       value={d.repo_id}
       onSelect={() => handlePick(d)}
       className="text-white aria-selected:bg-gray-700"
     >
-      <span className="flex-1 truncate">{d.repo_id}</span>
+      <div className="flex-1 min-w-0">
+        <span className="block truncate">{d.repo_id}</span>
+        {detailParts.length > 0 && (
+          <span className="block text-xs text-gray-400">
+            {detailParts.join(" · ")}
+          </span>
+        )}
+        {progress !== null && (
+          <span className="mt-1 block h-1 w-full rounded bg-gray-700">
+            <span
+              className={`block h-1 rounded ${progress >= 100 ? "bg-green-500" : "bg-red-400"}`}
+              style={{ width: `${progress}%` }}
+            />
+          </span>
+        )}
+      </div>
       {d.source === "both" && (
         <span className="text-xs text-gray-400 mr-2">on Hub</span>
       )}
       {d.private && (
         <span className="text-xs text-amber-400">private</span>
       )}
+      {(d.source === "local" || d.source === "both") && onResumeExisting && (
+        <button
+          type="button"
+          title="Continue recording: append new episodes to this dataset"
+          onClick={(e) => {
+            e.stopPropagation();
+            onResumeExisting(d);
+            reset();
+          }}
+          className="ml-2 flex shrink-0 items-center gap-1 rounded-full border border-gray-600 px-2 py-0.5 text-xs text-gray-300 hover:border-red-400 hover:text-red-400 hover:bg-gray-700"
+        >
+          <Plus className="h-3 w-3" />
+          episodes
+        </button>
+      )}
     </CommandItem>
-  );
+    );
+  };
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/frontend/src/components/landing/InferenceModal.tsx
+++ b/frontend/src/components/landing/InferenceModal.tsx
@@ -30,6 +30,7 @@ import {
   listJobCheckpoints,
 } from "@/lib/checkpointsApi";
 import { startInference } from "@/lib/inferenceApi";
+import { saveDemoPreset } from "@/lib/demoPreset";
 import CheckpointDropdown from "@/components/jobs/CheckpointDropdown";
 import { useAvailableCameras } from "@/hooks/useAvailableCameras";
 import { useCameraStream } from "@/hooks/useCameraStream";
@@ -225,14 +226,22 @@ const InferenceModal: React.FC<Props> = ({
         fps: DEFAULT_FPS,
       };
     }
+    const request = {
+      follower_port: robot.follower_port,
+      follower_config: robot.follower_config,
+      policy_ref: selectedRef,
+      task,
+      cameras: cameraDict,
+      duration_s: durationS,
+    };
     try {
-      await startInference(baseUrl, fetchWithHeaders, {
-        follower_port: robot.follower_port,
-        follower_config: robot.follower_config,
-        policy_ref: selectedRef,
-        task,
-        cameras: cameraDict,
-        duration_s: durationS,
+      await startInference(baseUrl, fetchWithHeaders, request);
+      // The last successfully started inference becomes the demo-mode preset.
+      saveDemoPreset({
+        request,
+        policyLabel: `${jobId} · step ${selectedStep}`,
+        robotName: robot.name,
+        savedAt: new Date().toISOString(),
       });
       onOpenChange(false);
       navigate("/inference");

--- a/frontend/src/components/landing/RecordingModal.tsx
+++ b/frontend/src/components/landing/RecordingModal.tsx
@@ -17,17 +17,22 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { AlertTriangle, CheckCircle, ChevronDown } from "lucide-react";
+import { AlertTriangle, CheckCircle, ChevronDown, Disc } from "lucide-react";
 import CameraConfiguration, {
   CameraConfig,
 } from "@/components/recording/CameraConfiguration";
 import { useHfAuth } from "@/contexts/HfAuthContext";
 import { RobotRecord } from "@/hooks/useRobots";
+import { ResumeDatasetInfo } from "@/pages/Landing";
 
 interface RecordingModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   robot: RobotRecord | null;
+  resumeMode?: boolean;
+  resumeInfo?: ResumeDatasetInfo | null;
+  episodeTarget?: number | null;
+  setEpisodeTarget?: (value: number | null) => void;
   datasetName: string;
   setDatasetName: (value: string) => void;
   singleTask: string;
@@ -50,6 +55,10 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
   open,
   onOpenChange,
   robot,
+  resumeMode = false,
+  resumeInfo = null,
+  episodeTarget = null,
+  setEpisodeTarget,
   datasetName,
   setDatasetName,
   singleTask,
@@ -69,7 +78,17 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
 }) => {
   const { auth } = useHfAuth();
 
-  const canStart = !!robot && robot.is_clean;
+  const configuredCameraNames = cameras.map((c) => c.name);
+  const missingCameras = resumeInfo
+    ? resumeInfo.cameras.filter((c) => !configuredCameraNames.includes(c))
+    : [];
+  const extraCameras = resumeInfo
+    ? configuredCameraNames.filter((c) => !resumeInfo.cameras.includes(c))
+    : [];
+  const camerasMatch = missingCameras.length === 0 && extraCameras.length === 0;
+  const setupOk = !resumeMode || !resumeInfo || camerasMatch;
+
+  const canStart = !!robot && robot.is_clean && setupOk;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -81,7 +100,7 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
             </div>
           </div>
           <DialogTitle className="text-white text-center text-2xl font-bold">
-            Configure Recording
+            {resumeMode ? "Continue Recording" : "Configure Recording"}
           </DialogTitle>
         </DialogHeader>
         <div className="space-y-6 py-4">
@@ -124,6 +143,84 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
               <h3 className="text-lg font-semibold text-white border-b border-gray-700 pb-2">
                 Dataset Configuration
               </h3>
+              {resumeMode && (
+                <Alert className="bg-blue-900/40 border-blue-700 text-blue-100">
+                  <Disc className="h-4 w-4" />
+                  <AlertDescription>
+                    New episodes will be appended to{" "}
+                    <strong className="font-mono">{datasetName}</strong>
+                    {resumeInfo && (
+                      <> ({resumeInfo.numEpisodes} episodes so far)</>
+                    )}
+                    . The setup must match the original recording exactly.
+                  </AlertDescription>
+                </Alert>
+              )}
+              {resumeMode && resumeInfo && (
+                <div className="rounded-lg border border-gray-700 bg-gray-800/60 p-3 space-y-2">
+                  <p className="text-sm font-medium text-gray-200">
+                    Required setup (from the dataset)
+                  </p>
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 text-xs">
+                    <div className="rounded bg-gray-800 border border-gray-700 px-2 py-1.5">
+                      <span className="text-gray-500 block">Robot type</span>
+                      <span className="text-gray-200 font-mono">
+                        {resumeInfo.robotType}
+                      </span>
+                    </div>
+                    <div className="rounded bg-gray-800 border border-gray-700 px-2 py-1.5">
+                      <span className="text-gray-500 block">FPS</span>
+                      <span className="text-gray-200 font-mono">
+                        {resumeInfo.fps}
+                      </span>
+                    </div>
+                    <div
+                      className={`rounded px-2 py-1.5 border ${
+                        camerasMatch
+                          ? "bg-gray-800 border-gray-700"
+                          : "bg-red-900/40 border-red-700"
+                      }`}
+                    >
+                      <span className="text-gray-500 block">Cameras</span>
+                      <span
+                        className={`font-mono ${camerasMatch ? "text-gray-200" : "text-red-300"}`}
+                      >
+                        {resumeInfo.cameras.join(", ") || "none"}
+                      </span>
+                    </div>
+                  </div>
+                  {!camerasMatch && (
+                    <Alert className="bg-red-900/40 border-red-700 text-red-100">
+                      <AlertTriangle className="h-4 w-4" />
+                      <AlertDescription className="text-xs">
+                        Camera setup doesn&apos;t match the dataset.
+                        {missingCameras.length > 0 && (
+                          <>
+                            {" "}
+                            Missing:{" "}
+                            <strong className="font-mono">
+                              {missingCameras.join(", ")}
+                            </strong>
+                            .
+                          </>
+                        )}
+                        {extraCameras.length > 0 && (
+                          <>
+                            {" "}
+                            Not in the dataset:{" "}
+                            <strong className="font-mono">
+                              {extraCameras.join(", ")}
+                            </strong>
+                            .
+                          </>
+                        )}{" "}
+                        Rename or adjust your cameras below to match, then the
+                        button will unlock.
+                      </AlertDescription>
+                    </Alert>
+                  )}
+                </div>
+              )}
               <div className="grid grid-cols-1 gap-4">
                 <div className="space-y-2">
                   <Label
@@ -135,20 +232,24 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
                   <Input
                     id="datasetName"
                     value={datasetName}
+                    disabled={resumeMode}
                     onChange={(e) =>
                       setDatasetName(
                         e.target.value.replace(/[^A-Za-z0-9._-]/g, "_")
                       )
                     }
                     placeholder="my_dataset"
-                    className="bg-gray-800 border-gray-700 text-white"
+                    className="bg-gray-800 border-gray-700 text-white disabled:opacity-60"
                   />
-                  <p className="text-xs text-gray-500">
-                    Letters, numbers, <code>.</code> <code>_</code>{" "}
-                    <code>-</code> only — other characters become{" "}
-                    <code>_</code>.
-                  </p>
+                  {!resumeMode && (
+                    <p className="text-xs text-gray-500">
+                      Letters, numbers, <code>.</code> <code>_</code>{" "}
+                      <code>-</code> only — other characters become{" "}
+                      <code>_</code>.
+                    </p>
+                  )}
                   {datasetName &&
+                    !resumeMode &&
                     (auth.status === "authenticated" ? (
                       <p className="text-xs text-gray-500">
                         Will be saved as{" "}
@@ -177,23 +278,46 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
                     className="bg-gray-800 border-gray-700 text-white"
                   />
                 </div>
-                <div className="space-y-2">
-                  <Label
-                    htmlFor="numEpisodes"
-                    className="text-sm font-medium text-gray-300"
-                  >
-                    Number of Episodes
-                  </Label>
-                  <NumberInput
-                    id="numEpisodes"
-                    min="1"
-                    max="100"
-                    value={numEpisodes}
-                    onChange={(v) => {
-                      if (v !== undefined) setNumEpisodes(v);
-                    }}
-                    className="bg-gray-800 border-gray-700 text-white"
-                  />
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="numEpisodes"
+                      className="text-sm font-medium text-gray-300"
+                    >
+                      {resumeMode ? "Episodes to add" : "Number of Episodes"}
+                    </Label>
+                    <NumberInput
+                      id="numEpisodes"
+                      min="1"
+                      max="100"
+                      value={numEpisodes}
+                      onChange={(v) => {
+                        if (v !== undefined) setNumEpisodes(v);
+                      }}
+                      className="bg-gray-800 border-gray-700 text-white"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="episodeTarget"
+                      className="text-sm font-medium text-gray-300"
+                    >
+                      Episode goal (optional)
+                    </Label>
+                    <NumberInput
+                      id="episodeTarget"
+                      min="1"
+                      value={episodeTarget ?? undefined}
+                      onChange={(v) => {
+                        setEpisodeTarget?.(v ?? null);
+                      }}
+                      className="bg-gray-800 border-gray-700 text-white"
+                    />
+                    <p className="text-xs text-gray-500">
+                      Total episodes you aim for across all sessions — shows
+                      progress in the dataset list.
+                    </p>
+                  </div>
                 </div>
                 <div className="grid grid-cols-2 gap-4">
                   <div className="space-y-2">
@@ -281,7 +405,7 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
               disabled={!canStart}
               className="w-full sm:w-auto bg-red-500 hover:bg-red-600 text-white px-10 py-6 text-lg transition-all shadow-md shadow-red-500/30 hover:shadow-lg hover:shadow-red-500/40 disabled:opacity-40 disabled:cursor-not-allowed"
             >
-              Start Recording
+              {resumeMode ? "Resume Recording" : "Start Recording"}
             </Button>
             <Button
               onClick={() => onOpenChange(false)}

--- a/frontend/src/lib/demoPreset.ts
+++ b/frontend/src/lib/demoPreset.ts
@@ -1,0 +1,29 @@
+import { StartInferenceRequest } from "./inferenceApi";
+
+const STORAGE_KEY = "lelab-demo-preset";
+
+export interface DemoPreset {
+  request: StartInferenceRequest;
+  policyLabel: string;
+  robotName: string;
+  savedAt: string;
+}
+
+export function getDemoPreset(): DemoPreset | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const preset = JSON.parse(raw) as DemoPreset;
+    return preset && preset.request ? preset : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveDemoPreset(preset: DemoPreset) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(preset));
+  } catch {
+    // localStorage unavailable — demo mode simply stays unconfigured.
+  }
+}

--- a/frontend/src/lib/episodeTargets.ts
+++ b/frontend/src/lib/episodeTargets.ts
@@ -1,0 +1,36 @@
+const STORAGE_KEY = "lelab-episode-targets";
+
+type TargetMap = Record<string, number>;
+
+function readMap(): TargetMap {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as TargetMap) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeMap(map: TargetMap) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // localStorage unavailable (private mode, etc.) — targets are a comfort
+    // feature, silently skip.
+  }
+}
+
+export function getEpisodeTarget(repoId: string): number | null {
+  const value = readMap()[repoId];
+  return typeof value === "number" && value > 0 ? value : null;
+}
+
+export function setEpisodeTarget(repoId: string, target: number | null) {
+  const map = readMap();
+  if (target && target > 0) {
+    map[repoId] = target;
+  } else {
+    delete map[repoId];
+  }
+  writeMap(map);
+}

--- a/frontend/src/lib/replayApi.ts
+++ b/frontend/src/lib/replayApi.ts
@@ -7,6 +7,7 @@ export interface DatasetItem {
   last_modified: string | null;
   private: boolean;
   source: DatasetSource;
+  num_episodes?: number | null;
 }
 
 export async function listDatasets(

--- a/frontend/src/pages/Demo.tsx
+++ b/frontend/src/pages/Demo.tsx
@@ -1,0 +1,262 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowLeft, Maximize, Minimize, Play, Square } from "lucide-react";
+import { useApi } from "@/contexts/ApiContext";
+import { useToast } from "@/hooks/use-toast";
+import {
+  InferenceStatus,
+  getInferenceStatus,
+  startInference,
+  stopInference,
+} from "@/lib/inferenceApi";
+import { DemoPreset, getDemoPreset } from "@/lib/demoPreset";
+
+const formatTime = (totalSeconds: number): string => {
+  const s = Math.max(0, Math.floor(totalSeconds));
+  const mins = Math.floor(s / 60);
+  const secs = s % 60;
+  return `${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+};
+
+const CameraFeed: React.FC<{
+  baseUrl: string;
+  camId: number;
+  label: string;
+}> = ({ baseUrl, camId, label }) => {
+  const [tick, setTick] = useState(0);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 150);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="relative rounded-xl overflow-hidden border border-gray-800 bg-gray-900 min-h-[180px] flex items-center justify-center">
+      {!loaded && (
+        <span className="absolute text-gray-600 text-sm">
+          waiting for camera…
+        </span>
+      )}
+      <img
+        src={`${baseUrl}/demo-camera/${camId}?t=${tick}`}
+        alt={`Live camera ${label}`}
+        onLoad={() => setLoaded(true)}
+        className={`w-full h-full object-contain ${loaded ? "opacity-100" : "opacity-0"}`}
+      />
+      <span className="absolute bottom-2 left-3 text-xs text-gray-300 bg-black/60 rounded px-2 py-0.5">
+        {label}
+      </span>
+    </div>
+  );
+};
+
+const Demo = () => {
+  const navigate = useNavigate();
+  const { baseUrl, fetchWithHeaders } = useApi();
+  const { toast } = useToast();
+
+  const [preset] = useState<DemoPreset | null>(() => getDemoPreset());
+  const [status, setStatus] = useState<InferenceStatus | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const active = !!status?.inference_active;
+
+  useEffect(() => {
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const s = await getInferenceStatus(baseUrl, fetchWithHeaders);
+        if (!cancelled) setStatus(s);
+      } catch {
+        if (!cancelled) setStatus(null);
+      }
+    };
+    poll();
+    const id = setInterval(poll, 1000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [baseUrl, fetchWithHeaders]);
+
+  useEffect(() => {
+    const onChange = () => setIsFullscreen(!!document.fullscreenElement);
+    document.addEventListener("fullscreenchange", onChange);
+    return () => document.removeEventListener("fullscreenchange", onChange);
+  }, []);
+
+  const toggleFullscreen = useCallback(() => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+    } else {
+      document.documentElement.requestFullscreen().catch(() => {
+        // Fullscreen may be blocked (iframe/permissions) — non-fatal.
+      });
+    }
+  }, []);
+
+  const handleStart = async () => {
+    if (!preset) return;
+    setSubmitting(true);
+    try {
+      await startInference(baseUrl, fetchWithHeaders, preset.request);
+    } catch (e) {
+      toast({
+        title: "Couldn't start the demo",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleStop = async () => {
+    setSubmitting(true);
+    try {
+      await stopInference(baseUrl, fetchWithHeaders);
+    } catch (e) {
+      toast({
+        title: "Couldn't stop the demo",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const elapsed = status?.rollout_elapsed_s ?? status?.elapsed_s ?? 0;
+  const duration = status?.duration_s ?? preset?.request.duration_s ?? 0;
+  const progress =
+    active && duration > 0 ? Math.min(100, (elapsed / duration) * 100) : 0;
+
+  return (
+    <div className="min-h-screen bg-black text-white flex flex-col select-none">
+      <div className="flex items-center justify-between p-4">
+        <button
+          onClick={() => navigate("/")}
+          className="flex items-center gap-2 text-gray-600 hover:text-gray-300 text-sm transition-colors"
+          aria-label="Back to home"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          exit
+        </button>
+        <button
+          onClick={toggleFullscreen}
+          className="text-gray-600 hover:text-gray-300 transition-colors"
+          aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+        >
+          {isFullscreen ? (
+            <Minimize className="w-5 h-5" />
+          ) : (
+            <Maximize className="w-5 h-5" />
+          )}
+        </button>
+      </div>
+
+      <div className="flex-1 flex flex-col items-center justify-center gap-10 px-6 pb-16">
+        {!preset ? (
+          <div className="text-center max-w-md space-y-4">
+            <h1 className="text-3xl font-bold">Demo mode</h1>
+            <p className="text-gray-400 leading-relaxed">
+              No demo configured yet. Run an inference once from the landing
+              page (green play button on a trained model) — its exact settings
+              will be reused here for one-click demos.
+            </p>
+            <button
+              onClick={() => navigate("/")}
+              className="text-red-400 hover:text-red-300 underline underline-offset-4"
+            >
+              Go to the landing page
+            </button>
+          </div>
+        ) : active ? (
+          <>
+            <div className="flex items-center gap-3 text-gray-400">
+              <span className="relative flex h-3 w-3">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+                <span className="relative inline-flex rounded-full h-3 w-3 bg-green-500" />
+              </span>
+              Robot running
+            </div>
+            {!status?.rollout_started_at ? (
+              <div className="flex flex-col items-center gap-3 text-gray-400">
+                <span className="h-10 w-10 rounded-full border-4 border-gray-700 border-t-green-500 animate-spin" />
+                <span>Loading policy — the robot will move in ~30 s…</span>
+              </div>
+            ) : (
+              Object.keys(preset.request.cameras).length > 0 && (
+                <div
+                  className={`grid gap-4 w-full max-w-4xl ${
+                    Object.keys(preset.request.cameras).length > 1
+                      ? "grid-cols-1 sm:grid-cols-2"
+                      : "grid-cols-1"
+                  }`}
+                >
+                  {Object.entries(preset.request.cameras).map(([name, cfg]) => (
+                    <CameraFeed
+                      key={name}
+                      baseUrl={baseUrl}
+                      camId={cfg.camera_index ?? 0}
+                      label={name}
+                    />
+                  ))}
+                </div>
+              )
+            )}
+            <div className="text-6xl md:text-7xl font-bold font-mono tabular-nums">
+              {formatTime(elapsed)}
+            </div>
+            {duration > 0 && (
+              <div className="w-full max-w-xl h-2 rounded-full bg-gray-800 overflow-hidden">
+                <div
+                  className="h-full bg-green-500 transition-all duration-1000 ease-linear"
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+            )}
+            <button
+              onClick={handleStop}
+              disabled={submitting}
+              className="mt-4 flex items-center justify-center gap-3 rounded-full bg-red-600 hover:bg-red-500 disabled:opacity-50 text-white text-2xl font-bold px-14 py-6 shadow-lg shadow-red-600/30 transition-all active:scale-95"
+            >
+              <Square className="w-7 h-7 fill-current" />
+              STOP
+            </button>
+          </>
+        ) : (
+          <>
+            <div className="text-center space-y-2">
+              <h1 className="text-3xl md:text-4xl font-bold">
+                {preset.request.task || "Robot demo"}
+              </h1>
+              <p className="text-gray-500 text-sm">
+                {preset.policyLabel} · {preset.robotName} ·{" "}
+                {preset.request.duration_s}s
+              </p>
+            </div>
+            <button
+              onClick={handleStart}
+              disabled={submitting}
+              className="flex items-center justify-center gap-4 rounded-full bg-green-600 hover:bg-green-500 disabled:opacity-50 text-white text-3xl font-bold px-16 py-8 shadow-lg shadow-green-600/30 transition-all active:scale-95"
+            >
+              <Play className="w-9 h-9 fill-current" />
+              {submitting ? "STARTING…" : "START"}
+            </button>
+            {status?.exited && status.exit_code !== 0 && status.exit_code != null && (
+              <p className="text-xs text-red-400">
+                Last run exited with code {status.exit_code} — check the
+                inference page for logs.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Demo;

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -12,13 +12,23 @@ import JobsSection from "@/components/jobs/JobsSection";
 
 import UsageInstructionsModal from "@/components/landing/UsageInstructionsModal";
 import { useHfAuth } from "@/contexts/HfAuthContext";
+import { useApi } from "@/contexts/ApiContext";
 import { useRobots } from "@/hooks/useRobots";
 import { useDatasets } from "@/hooks/useDatasets";
 import { DatasetItem } from "@/lib/replayApi";
+import { getEpisodeTarget } from "@/lib/episodeTargets";
 import { CameraConfig } from "@/components/recording/CameraConfiguration";
 import { isHostedSpace } from "@/lib/isHostedSpace";
 
 const ON_SPACE = isHostedSpace();
+
+export interface ResumeDatasetInfo {
+  fps: number;
+  cameras: string[];
+  robotType: string;
+  numEpisodes: number;
+  task: string | null;
+}
 
 const Landing = () => {
   const [showUsageModal, setShowUsageModal] = useState(ON_SPACE);
@@ -45,6 +55,10 @@ const Landing = () => {
   const [resetTimeS, setResetTimeS] = useState(15);
   const [streamingEncoding, setStreamingEncoding] = useState(true);
   const [cameras, setCameras] = useState<CameraConfig[]>([]);
+  const [resumeMode, setResumeMode] = useState(false);
+  const [resumeInfo, setResumeInfo] = useState<ResumeDatasetInfo | null>(null);
+  const [episodeTarget, setEpisodeTargetState] = useState<number | null>(null);
+  const { baseUrl, fetchWithHeaders } = useApi();
 
   const releaseStreamsRef = useRef<(() => void) | null>(null);
 
@@ -80,6 +94,11 @@ const Landing = () => {
 
   const handleRecordingModalClose = (open: boolean) => {
     setShowRecordingModal(open);
+    if (!open && resumeMode) {
+      setResumeMode(false);
+      setResumeInfo(null);
+      setDatasetName("");
+    }
     if (!open && releaseStreamsRef.current) {
       console.log("🧹 Modal closed: Releasing camera streams");
       releaseStreamsRef.current();
@@ -118,8 +137,47 @@ const Landing = () => {
   };
 
   const handleCreateDataset = (name: string) => {
+    setResumeMode(false);
+    setEpisodeTargetState(null);
     setDatasetName(name);
     openRecordingModal();
+  };
+
+  const handleResumeDataset = async (item: DatasetItem) => {
+    setResumeMode(true);
+    setDatasetName(item.repo_id);
+    setResumeInfo(null);
+    setEpisodeTargetState(getEpisodeTarget(item.repo_id));
+    openRecordingModal();
+    try {
+      const response = await fetchWithHeaders(`${baseUrl}/dataset-info`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ dataset_repo_id: item.repo_id }),
+      });
+      const info = await response.json();
+      if (!info.success) return;
+      const cameras = (info.features ?? [])
+        .filter((f: string) => f.startsWith("observation.images."))
+        .map((f: string) => f.split(".").pop() as string);
+      const tasks: string[] = info.tasks ?? [];
+      const task =
+        tasks.length > 0
+          ? tasks[tasks.length - 1]
+          : info.single_task && info.single_task !== "Unknown task"
+            ? info.single_task
+            : null;
+      setResumeInfo({
+        fps: info.fps ?? 30,
+        cameras,
+        robotType: info.robot_type ?? "unknown",
+        numEpisodes: info.num_episodes ?? 0,
+        task,
+      });
+      if (task) setSingleTask(task);
+    } catch (e) {
+      console.warn("Could not load dataset info for resume:", e);
+    }
   };
 
   const handleStartRecording = async () => {
@@ -149,8 +207,9 @@ const Landing = () => {
       return;
     }
 
-    const datasetRepoId =
-      auth.status === "authenticated"
+    const datasetRepoId = resumeMode
+      ? datasetName
+      : auth.status === "authenticated"
         ? `${auth.username}/${datasetName}`
         : datasetName;
 
@@ -207,12 +266,13 @@ const Landing = () => {
       num_episodes: numEpisodes,
       episode_time_s: episodeTimeS,
       reset_time_s: resetTimeS,
-      fps: 30,
+      fps: resumeMode && resumeInfo ? resumeInfo.fps : 30,
       video: true,
       push_to_hub: false,
-      resume: false,
+      resume: resumeMode,
       streaming_encoding: streamingEncoding,
       cameras: cameraDict,
+      episode_target: episodeTarget,
     };
 
     setShowRecordingModal(false);
@@ -249,6 +309,7 @@ const Landing = () => {
                 datasets={datasets}
                 loading={datasetsLoading}
                 onPickExisting={handlePickExisting}
+                onResumeExisting={handleResumeDataset}
                 onOpenCustom={handleOpenCustom}
                 onCreateNew={handleCreateDataset}
               >
@@ -270,12 +331,21 @@ const Landing = () => {
               <h3 className="font-semibold text-lg text-left h-10 flex items-center">
                 Create a model
               </h3>
-              <Button
-                onClick={handleTrainingClick}
-                className="w-full bg-green-500 hover:bg-green-600 text-white"
-              >
-                Training
-              </Button>
+              <div className="flex gap-2">
+                <Button
+                  onClick={handleTrainingClick}
+                  className="flex-1 bg-green-500 hover:bg-green-600 text-white"
+                >
+                  Training
+                </Button>
+                <Button
+                  onClick={() => navigate("/demo")}
+                  variant="outline"
+                  className="flex-1 border-gray-600 text-gray-300 bg-gray-800 hover:bg-gray-700 hover:text-white"
+                >
+                  Demo mode
+                </Button>
+              </div>
             </div>
           </div>
         </div>
@@ -297,6 +367,10 @@ const Landing = () => {
         open={showRecordingModal}
         onOpenChange={handleRecordingModalClose}
         robot={selectedRecord}
+        resumeMode={resumeMode}
+        resumeInfo={resumeInfo}
+        episodeTarget={episodeTarget}
+        setEpisodeTarget={setEpisodeTargetState}
         datasetName={datasetName}
         setDatasetName={setDatasetName}
         singleTask={singleTask}

--- a/frontend/src/pages/Recording.tsx
+++ b/frontend/src/pages/Recording.tsx
@@ -25,6 +25,7 @@ import {
   playResetStartCue,
   playAutoAdvanceWarning,
 } from "@/lib/recordingAudio";
+import { setEpisodeTarget } from "@/lib/episodeTargets";
 import { useApi } from "@/contexts/ApiContext";
 import {
   AlertDialog,
@@ -52,6 +53,7 @@ interface RecordingConfig {
   push_to_hub: boolean;
   resume: boolean;
   streaming_encoding: boolean;
+  episode_target?: number | null;
 }
 
 type Phase = "preparing" | "recording" | "resetting" | "completed";
@@ -225,6 +227,12 @@ const Recording = () => {
       const data = await response.json();
 
       if (response.ok) {
+        if (recordingConfig.episode_target) {
+          setEpisodeTarget(
+            data.dataset_id ?? recordingConfig.dataset_repo_id,
+            recordingConfig.episode_target,
+          );
+        }
         setRecordingSessionStarted(true);
         toast({
           title: "Recording Started",

--- a/lelab/datasets.py
+++ b/lelab/datasets.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 import os
 from datetime import UTC, datetime
@@ -42,6 +43,17 @@ def _dir_mtime_iso(path: Path) -> str | None:
         ts = path.stat().st_mtime
         return datetime.fromtimestamp(ts, tz=UTC).isoformat()
     except OSError:
+        return None
+
+
+def _dataset_episode_count(path: Path) -> int | None:
+    """Episode count from <dir>/meta/info.json, without loading the dataset."""
+    try:
+        with open(path / "meta" / "info.json", encoding="utf-8") as f:
+            info = json.load(f)
+        count = info.get("total_episodes")
+        return int(count) if count is not None else None
+    except (OSError, ValueError, TypeError):
         return None
 
 
@@ -76,6 +88,7 @@ def list_local_datasets() -> list[dict[str, Any]]:
                     "repo_id": top.name,
                     "last_modified": _dir_mtime_iso(top),
                     "private": False,
+                    "num_episodes": _dataset_episode_count(top),
                 }
             )
             continue
@@ -97,6 +110,7 @@ def list_local_datasets() -> list[dict[str, Any]]:
                         "repo_id": f"{top.name}/{sub.name}",
                         "last_modified": _dir_mtime_iso(sub),
                         "private": False,
+                        "num_episodes": _dataset_episode_count(sub),
                     }
                 )
 
@@ -150,6 +164,7 @@ def list_all_datasets() -> list[dict[str, Any]]:
         if rid in merged:
             existing = merged[rid]
             existing["source"] = "both"
+            existing["num_episodes"] = item.get("num_episodes")
             # Keep the newer timestamp; ISO strings sort lexically.
             a = existing.get("last_modified") or ""
             b = item.get("last_modified") or ""

--- a/lelab/record.py
+++ b/lelab/record.py
@@ -23,6 +23,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from lerobot.configs.dataset import DatasetRecordConfig
+from lerobot.configs.video import RGBEncoderConfig
 from lerobot.datasets import LeRobotDataset
 from lerobot.robots.so_follower import SO101FollowerConfig
 
@@ -182,6 +183,10 @@ def create_record_config(request: RecordingRequest) -> RecordConfig:
         tags=with_lelab_tag(request.tags) if request.push_to_hub else None,
         private=request.private,
         streaming_encoding=request.streaming_encoding,
+        # libsvtav1 (lerobot's default) is CPU-heavy enough on this machine to starve
+        # the motor bus read loop mid-recording ("no status packet" ConnectionError,
+        # see 2026-07-15 crashes). h264/ultrafast measured ~11x faster to encode here.
+        rgb_encoder=RGBEncoderConfig(vcodec="h264", preset="ultrafast"),
     )
 
     # Create the main record config
@@ -308,11 +313,15 @@ def handle_start_recording(request: RecordingRequest) -> dict[str, Any]:
                     "robot_type": getattr(dataset.meta, "robot_type", "Unknown robot"),
                 }
             except Exception as e:
-                logger.exception("Recording session failed")
+                logger.exception("Recording session failed: %r", e)
                 current_phase = "error"
                 if recording_start_time:
                     session_end_elapsed_seconds = int(time.time() - recording_start_time)
-                last_recording_info = {"success": False, "error": str(e)}
+                last_recording_info = {
+                    "success": False,
+                    "error": str(e) or repr(e),
+                    "dataset_repo_id": request.dataset_repo_id,
+                }
             finally:
                 if current_phase != "error":
                     current_phase = "completed"
@@ -418,7 +427,11 @@ def handle_recording_status() -> dict[str, Any]:
             "rerecord_episode": recording_active
             and current_phase == "recording",  # Only during recording phase
         },
-        "message": "Recording session failed with error - check logs"
+        "message": (
+            f"Recording failed: {last_recording_info['error']}"
+            if last_recording_info and last_recording_info.get("error")
+            else "Recording session failed with error - check logs"
+        )
         if current_phase == "error"
         else (
             "Recording session has ended - stop polling"
@@ -469,11 +482,16 @@ def handle_get_dataset_info(request: DatasetInfoRequest) -> dict[str, Any]:
         from lerobot.datasets import LeRobotDataset
 
         dataset = LeRobotDataset(request.dataset_repo_id)
+        try:
+            tasks = [str(t) for t in dataset.meta.tasks.index]
+        except Exception:
+            tasks = []
         return {
             "success": True,
             "dataset_repo_id": request.dataset_repo_id,
             "num_episodes": dataset.num_episodes,
             "single_task": getattr(dataset.meta, "single_task", "Unknown task"),
+            "tasks": tasks,
             "fps": dataset.fps,
             "features": list(dataset.features.keys()),
             "total_frames": dataset.num_frames,
@@ -596,9 +614,17 @@ def record_with_web_events(cfg: RecordConfig, web_events: dict) -> LeRobotDatase
 
     if cfg.resume:
         num_cameras = len(robot.cameras) if hasattr(robot, "cameras") else 0
+        # LeRobotDataset.resume() refuses root=None (it would write into the
+        # revision-safe Hub snapshot cache), so resolve the same default local
+        # directory that LeRobotDataset.create() uses.
+        resume_root = cfg.dataset.root
+        if resume_root is None:
+            from lerobot.utils.constants import HF_LEROBOT_HOME
+
+            resume_root = HF_LEROBOT_HOME / cfg.dataset.repo_id
         dataset = LeRobotDataset.resume(
             cfg.dataset.repo_id,
-            root=cfg.dataset.root,
+            root=resume_root,
             batch_encoding_size=cfg.dataset.video_encoding_batch_size,
             rgb_encoder=cfg.dataset.rgb_encoder,
             depth_encoder=cfg.dataset.depth_encoder,

--- a/lelab/rollout.py
+++ b/lelab/rollout.py
@@ -41,6 +41,13 @@ from .utils.config import setup_follower_calibration_file
 logger = logging.getLogger(__name__)
 
 
+def demo_frames_dir() -> Path:
+    """Directory where the rollout wrapper drops live camera JPEGs."""
+    import tempfile
+
+    return Path(tempfile.gettempdir()) / "lelab_demo_frames"
+
+
 class InferenceRequest(BaseModel):
     follower_port: str
     follower_config: str
@@ -277,8 +284,16 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
         cmd = [
             sys.executable,
             "-m",
-            "lerobot.scripts.lerobot_rollout",
+            # Thin wrapper around lerobot.scripts.lerobot_rollout that also
+            # tees camera frames to disk for the demo page's live preview.
+            "lelab.rollout_frames",
             "--strategy.type=base",
+            # Tried --inference.type=rtc to eliminate the periodic ~200ms
+            # chunk-recompute stall, but this lerobot version's RTC engine
+            # calls ACTPolicy.predict_action_chunk(inference_delay=...) and
+            # ACT doesn't accept that kwarg (RTC targets flow-matching
+            # policies). Reverted to sync; see rollout_frames.py's prefetch
+            # tee for the ACT-specific fix instead.
             f"--policy.path={policy_path}",
             f"--policy.device={_detect_device()}",
             "--robot.type=so101_follower",
@@ -297,6 +312,7 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
 
         env = os.environ.copy()
         env["PYTHONUNBUFFERED"] = "1"
+        env["LELAB_DEMO_FRAMES_DIR"] = str(demo_frames_dir())
         # Feed a single newline into stdin so SOFollower.calibrate()'s
         # `input("Press ENTER to use the calibration file ...")` returns "" and
         # writes the existing calibration to the motors instead of hanging

--- a/lelab/rollout_frames.py
+++ b/lelab/rollout_frames.py
@@ -1,0 +1,189 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""lerobot_rollout wrapper with a live camera tee.
+
+The rollout subprocess has exclusive access to the cameras (OpenCV/DSHOW),
+so neither the LeLab server nor the browser can read them during inference.
+This wrapper monkeypatches ``OpenCVCamera.async_read`` to also write each
+camera's latest frame (throttled, atomically) as a JPEG under the directory
+given by ``LELAB_DEMO_FRAMES_DIR``. The LeLab server then serves those files
+to the demo page for a live preview.
+
+The tee must never break the rollout: every failure path is swallowed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+logger = logging.getLogger("lelab.rollout_frames")
+
+_TEE_INTERVAL_S = 0.1  # ~10 fps is plenty for a preview
+_JPEG_QUALITY = 80
+
+
+class _Accum:
+    """Thread-safe running total + count for a timed section."""
+
+    def __init__(self) -> None:
+        self.total = 0.0
+        self.count = 0
+        self.max = 0.0
+        self._lock = threading.Lock()
+
+    def add(self, dt: float) -> None:
+        with self._lock:
+            self.total += dt
+            self.count += 1
+            if dt > self.max:
+                self.max = dt
+
+    def drain(self) -> tuple[float, int, float]:
+        with self._lock:
+            avg = (self.total / self.count) if self.count else 0.0
+            out = (avg, self.count, self.max)
+            self.total = 0.0
+            self.count = 0
+            self.max = 0.0
+            return out
+
+
+def _install_profiler() -> None:
+    """Time obs-gather, camera reads, and inference; log a summary each second.
+
+    Enabled by LELAB_PROFILE=1. The variability of the rollout's control-loop
+    rate (0.6-29 Hz in logs) points at an I/O stall rather than compute; this
+    tells us definitively which stage costs the time.
+    """
+    if os.environ.get("LELAB_PROFILE") != "1":
+        return
+    try:
+        cam_read = _Accum()
+        obs_gather = _Accum()
+        inference = _Accum()
+
+        from lerobot.cameras.opencv import OpenCVCamera
+        from lerobot.robots.so_follower import SO101Follower
+
+        def time_method(cls, name, accum):
+            orig = getattr(cls, name, None)
+            if orig is None:
+                return
+
+            def wrapper(self, *args, **kwargs):
+                t0 = time.perf_counter()
+                try:
+                    return orig(self, *args, **kwargs)
+                finally:
+                    accum.add((time.perf_counter() - t0) * 1000)
+
+            setattr(cls, name, wrapper)
+
+        time_method(OpenCVCamera, "read_latest", cam_read)
+        time_method(SO101Follower, "get_observation", obs_gather)
+
+        # Inference engine: time the per-tick get_action.
+        try:
+            from lerobot.rollout.inference.sync import SyncInferenceEngine
+
+            time_method(SyncInferenceEngine, "get_action", inference)
+        except Exception:
+            pass
+
+        def report_loop():
+            while True:
+                time.sleep(1.0)
+                c_avg, c_n, c_max = cam_read.drain()
+                o_avg, o_n, o_max = obs_gather.drain()
+                i_avg, i_n, i_max = inference.drain()
+                logger.warning(
+                    "[PROFILE] obs_gather avg=%.0fms max=%.0fms n=%d | "
+                    "cam_read avg=%.0fms max=%.0fms n=%d | "
+                    "inference avg=%.0fms max=%.0fms n=%d",
+                    o_avg, o_max, o_n, c_avg, c_max, c_n, i_avg, i_max, i_n,
+                )
+
+        threading.Thread(target=report_loop, name="lelab-profiler", daemon=True).start()
+        logger.warning("[PROFILE] profiler installed")
+    except Exception:
+        pass
+
+
+def _install_camera_tee() -> None:
+    frames_dir = os.environ.get("LELAB_DEMO_FRAMES_DIR")
+    if not frames_dir:
+        return
+    try:
+        out_dir = Path(frames_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        for stale in out_dir.glob("*.jpg"):
+            stale.unlink(missing_ok=True)
+
+        import cv2
+        from lerobot.cameras.opencv import OpenCVCamera
+
+        def _tee(cam, frame):
+            try:
+                now = time.time()
+                if now - getattr(cam, "_lelab_tee_last", 0.0) >= _TEE_INTERVAL_S:
+                    cam._lelab_tee_last = now
+                    cam_id = getattr(cam.config, "index_or_path", "0")
+                    target = out_dir / f"cam{cam_id}.jpg"
+                    tmp = out_dir / f"cam{cam_id}.tmp.jpg"
+                    # lerobot frames are RGB by default; cv2 writes BGR.
+                    bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+                    if cv2.imwrite(str(tmp), bgr, [cv2.IMWRITE_JPEG_QUALITY, _JPEG_QUALITY]):
+                        os.replace(tmp, target)
+            except Exception:
+                pass
+
+        # The rollout control loop reads frames with read_latest(); setup and
+        # warmup paths use async_read(). Tee both so the preview stays live
+        # for the whole run.
+        for method_name in ("async_read", "read_latest"):
+            original = getattr(OpenCVCamera, method_name, None)
+            if original is None:
+                continue
+
+            def make_wrapper(orig):
+                def wrapper(self, *args, **kwargs):
+                    frame = orig(self, *args, **kwargs)
+                    if frame is not None:
+                        _tee(self, frame)
+                    return frame
+
+                return wrapper
+
+            setattr(OpenCVCamera, method_name, make_wrapper(original))
+    except Exception:
+        # Preview is best-effort; inference must run regardless.
+        pass
+
+
+def main() -> None:
+    _install_camera_tee()
+    _install_profiler()
+    from lerobot.scripts.lerobot_rollout import main as rollout_main
+
+    rollout_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/lelab/server.py
+++ b/lelab/server.py
@@ -36,6 +36,15 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import Response
 from starlette.types import Scope
 
+# Windows consoles often use a legacy code page (cp1252) that can't encode the
+# emoji used in log/print output; an unhandled UnicodeEncodeError inside an
+# endpoint then turns into a 500 and hides the real error from the frontend.
+# Replace unencodable characters instead of crashing.
+for _stream in (sys.stdout, sys.stderr):
+    if _stream is not None and hasattr(_stream, "reconfigure"):
+        with contextlib.suppress(Exception):
+            _stream.reconfigure(errors="replace")
+
 from . import datasets as dataset_browser
 
 # Import our custom calibration functionality
@@ -164,6 +173,11 @@ class ConnectionManager:
     def __init__(self):
         self.active_connections: list[WebSocket] = []
         self.broadcast_queue = queue.Queue()
+        # Latest-wins slot for live joint frames. Joint updates supersede one
+        # another, so a slow consumer must never make them pile up in the
+        # queue — otherwise the 3D view drifts further and further behind the
+        # real robot as the backlog grows.
+        self._latest_joint_frame: dict[str, Any] | None = None
         self.broadcast_thread = None
         self.is_running = False
         # Guards `active_connections` since the broadcast worker thread also
@@ -220,8 +234,18 @@ class ConnectionManager:
         try:
             while self.is_running:
                 try:
-                    # Get data from queue with timeout
-                    data = self.broadcast_queue.get(timeout=0.1)
+                    # Send the freshest joint frame first (latest-wins slot).
+                    # A frame published between the read and the reset below is
+                    # simply picked up on the next iteration.
+                    frame = self._latest_joint_frame
+                    if frame is not None:
+                        self._latest_joint_frame = None
+                        if self.active_connections:
+                            loop.run_until_complete(self._send_to_all_connections(frame))
+
+                    # Get data from queue with a short timeout so joint frames
+                    # are polled frequently enough to stay real-time.
+                    data = self.broadcast_queue.get(timeout=0.02)
                     if data is None:  # Poison pill to stop
                         break
 
@@ -258,6 +282,11 @@ class ConnectionManager:
     def broadcast_joint_data_sync(self, data: dict[str, Any]):
         """Thread-safe method to queue data for broadcasting"""
         if self.is_running and self.active_connections:
+            if isinstance(data, dict) and data.get("type") == "joint_update":
+                # Replace any unsent frame instead of queueing: only the most
+                # recent robot pose is worth sending.
+                self._latest_joint_frame = data
+                return
             try:
                 self.broadcast_queue.put_nowait(data)
             except queue.Full:
@@ -351,6 +380,21 @@ def stop_inference():
 @app.get("/inference-status")
 def inference_status():
     return handle_inference_status()
+
+
+@app.get("/demo-camera/{cam_id}")
+def demo_camera_frame(cam_id: str):
+    """Latest camera frame teed by the inference subprocess (demo preview)."""
+    from fastapi.responses import FileResponse
+
+    from .rollout import demo_frames_dir
+
+    if not cam_id.replace("_", "").isalnum():
+        raise HTTPException(status_code=400, detail="Invalid camera id")
+    path = demo_frames_dir() / f"cam{cam_id}.jpg"
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail="No frame available")
+    return FileResponse(path, media_type="image/jpeg", headers={"Cache-Control": "no-store"})
 
 
 @app.get("/health")
@@ -998,6 +1042,18 @@ def _windows_cameras() -> list[dict[str, Any]]:
     frontend match each index to the browser's ``MediaDeviceInfo.label`` for the
     live preview. Falls back to generic names if pygrabber is unavailable.
     """
+    # pygrabber uses COM, which must be initialized per-thread. FastAPI serves
+    # sync endpoints from a thread pool whose threads never call CoInitialize,
+    # so enumeration fails intermittently depending on which thread handles the
+    # request. Initialize COM here and balance with CoUninitialize.
+    import ctypes
+
+    com_initialized = False
+    try:
+        hr = ctypes.windll.ole32.CoInitialize(None)
+        com_initialized = hr in (0, 1)  # S_OK or S_FALSE (already initialized)
+    except Exception:
+        pass
     try:
         from pygrabber.dshow_graph import FilterGraph
 
@@ -1007,6 +1063,9 @@ def _windows_cameras() -> list[dict[str, Any]]:
         import cv2
 
         return _generic_cv2_cameras(cv2.CAP_DSHOW)
+    finally:
+        if com_initialized:
+            ctypes.windll.ole32.CoUninitialize()
     return [{"index": i, "name": name, "available": True} for i, name in enumerate(names)]
 
 

--- a/lelab/teleoperate.py
+++ b/lelab/teleoperate.py
@@ -47,6 +47,27 @@ _SO101_URDF_CORRECTIONS = {
     "elbow_flex": (+1, 1029),
 }
 
+
+def _load_urdf_view_zero() -> dict[str, dict[str, float]] | None:
+    """Per-arm 3D-view zero captured by the user at the URDF sleep pose.
+
+    The hardcoded tick corrections above assume a canonical calibration; real
+    calibrations vary enough that the 3D view can be wildly offset. If
+    ``calibration/urdf_view_zero.json`` exists (mapping motor name to
+    ``{"zero_deg": float, "sign": ±1}``), it takes priority:
+    URDF angle = sign * (raw_normalized_deg - zero_deg).
+    """
+    import json
+    from pathlib import Path
+
+    path = Path.home() / ".cache" / "huggingface" / "lerobot" / "calibration" / "urdf_view_zero.json"
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        return {k: v for k, v in data.items() if isinstance(v, dict) and "zero_deg" in v}
+    except (OSError, ValueError):
+        return None
+
 # Global variables for teleoperation state
 teleoperation_active = False
 teleoperation_thread: threading.Thread | None = None
@@ -85,6 +106,12 @@ def get_joint_positions_from_robot(robot) -> dict[str, float]:
     try:
         observation = robot.get_observation()
         calibration = robot.calibration or {}
+        view_zero = getattr(get_joint_positions_from_robot, "_view_zero_cache", "unset")
+        if view_zero == "unset":
+            view_zero = _load_urdf_view_zero()
+            get_joint_positions_from_robot._view_zero_cache = view_zero
+            if view_zero:
+                logger.info("Using user-captured urdf_view_zero.json for the 3D view")
 
         joint_positions: dict[str, float] = {}
         debug_rows = []
@@ -97,13 +124,17 @@ def get_joint_positions_from_robot(robot) -> dict[str, float]:
 
             raw_deg = observation[motor_key]
             angle_degrees = raw_deg
-            correction = _SO101_URDF_CORRECTIONS.get(motor_name)
-            if correction is not None and motor_name in calibration:
-                sign, urdf_zero_ticks = correction
-                cal = calibration[motor_name]
-                mid = (cal.range_min + cal.range_max) / 2
-                motor_at_urdf_zero = (urdf_zero_ticks - mid) * 360 / _STS3215_MAX_RES
-                angle_degrees = sign * (raw_deg - motor_at_urdf_zero)
+            if view_zero and motor_name in view_zero:
+                entry = view_zero[motor_name]
+                angle_degrees = float(entry.get("sign", 1)) * (raw_deg - float(entry["zero_deg"]))
+            else:
+                correction = _SO101_URDF_CORRECTIONS.get(motor_name)
+                if correction is not None and motor_name in calibration:
+                    sign, urdf_zero_ticks = correction
+                    cal = calibration[motor_name]
+                    mid = (cal.range_min + cal.range_max) / 2
+                    motor_at_urdf_zero = (urdf_zero_ticks - mid) * 360 / _STS3215_MAX_RES
+                    angle_degrees = sign * (raw_deg - motor_at_urdf_zero)
 
             joint_positions[urdf_joint_name] = angle_degrees * math.pi / 180.0
             debug_rows.append(
@@ -227,7 +258,7 @@ def handle_start_teleoperation(request: TeleoperateRequest, websocket_manager=No
             logger.info("Starting teleoperation loop...")
             try:
                 last_broadcast_time = 0
-                broadcast_interval = 0.05  # 20 FPS
+                broadcast_interval = 1 / 30  # 30 FPS
 
                 while teleoperation_active:
                     action = teleop_device.get_action()


### PR DESCRIPTION
- Resume an existing local/Hub dataset in the UI to record additional episodes across sessions (DatasetPicker, Landing, RecordingModal), with a setup-compatibility check (robot type, fps, cameras) before recording is allowed to start.
- Add a demo mode (Demo.tsx) with an auto-filled inference preset from the last recording, plus a low-fps camera stream for live viewing during demos.
- Fix camera COM CoInitialize handling and console cp1252 encoding issues on Windows (server.py).
- Fix LeRobotDataset.resume() being called with root=None, which lerobot rejects; resolve the same default local directory used by LeRobotDataset.create() instead (record.py).
- Surface recording-session error messages through /recording-status, and dataset tasks through /dataset-info (record.py).
- Default the RGB video encoder to h264/ultrafast instead of the libsvtav1 default: on modest CPUs, two parallel libsvtav1 streams can starve the motor-bus read loop mid-recording and abort the session with a serial ConnectionError.