### PR TITLE
feat: resume recording into an existing dataset across sessions

### DIFF
--- a/frontend/src/components/landing/DatasetPicker.tsx
+++ b/frontend/src/components/landing/DatasetPicker.tsx
@@ -14,11 +14,24 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { DatasetItem } from "@/lib/replayApi";
+import { getEpisodeTarget } from "@/lib/episodeTargets";
+
+function relativeDate(iso: string | null): string | null {
+  if (!iso) return null;
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const days = Math.floor(diffMs / 86_400_000);
+  if (days <= 0) return "today";
+  if (days === 1) return "yesterday";
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return months < 12 ? `${months}mo ago` : `${Math.floor(months / 12)}y ago`;
+}
 
 interface DatasetPickerProps {
   datasets: DatasetItem[];
   loading: boolean;
   onPickExisting: (item: DatasetItem) => void;
+  onResumeExisting?: (item: DatasetItem) => void;
   onCreateNew: (name: string) => void;
   onOpenCustom: (repoId: string) => void;
   children: React.ReactNode;
@@ -31,6 +44,7 @@ const DatasetPicker: React.FC<DatasetPickerProps> = ({
   datasets,
   loading,
   onPickExisting,
+  onResumeExisting,
   onCreateNew,
   onOpenCustom,
   children,
@@ -87,22 +101,69 @@ const DatasetPicker: React.FC<DatasetPickerProps> = ({
     reset();
   };
 
-  const renderItem = (d: DatasetItem) => (
+  const renderItem = (d: DatasetItem) => {
+    const target = getEpisodeTarget(d.repo_id);
+    const detailParts: string[] = [];
+    if (d.num_episodes != null) {
+      detailParts.push(
+        target
+          ? `${d.num_episodes}/${target} episodes`
+          : `${d.num_episodes} episodes`,
+      );
+    }
+    const rel = relativeDate(d.last_modified);
+    if (rel) detailParts.push(rel);
+    const progress =
+      target && d.num_episodes != null
+        ? Math.min(100, Math.round((d.num_episodes / target) * 100))
+        : null;
+    return (
     <CommandItem
       key={d.repo_id}
       value={d.repo_id}
       onSelect={() => handlePick(d)}
       className="text-white aria-selected:bg-gray-700"
     >
-      <span className="flex-1 truncate">{d.repo_id}</span>
+      <div className="flex-1 min-w-0">
+        <span className="block truncate">{d.repo_id}</span>
+        {detailParts.length > 0 && (
+          <span className="block text-xs text-gray-400">
+            {detailParts.join(" · ")}
+          </span>
+        )}
+        {progress !== null && (
+          <span className="mt-1 block h-1 w-full rounded bg-gray-700">
+            <span
+              className={`block h-1 rounded ${progress >= 100 ? "bg-green-500" : "bg-red-400"}`}
+              style={{ width: `${progress}%` }}
+            />
+          </span>
+        )}
+      </div>
       {d.source === "both" && (
         <span className="text-xs text-gray-400 mr-2">on Hub</span>
       )}
       {d.private && (
         <span className="text-xs text-amber-400">private</span>
       )}
+      {(d.source === "local" || d.source === "both") && onResumeExisting && (
+        <button
+          type="button"
+          title="Continue recording: append new episodes to this dataset"
+          onClick={(e) => {
+            e.stopPropagation();
+            onResumeExisting(d);
+            reset();
+          }}
+          className="ml-2 flex shrink-0 items-center gap-1 rounded-full border border-gray-600 px-2 py-0.5 text-xs text-gray-300 hover:border-red-400 hover:text-red-400 hover:bg-gray-700"
+        >
+          <Plus className="h-3 w-3" />
+          episodes
+        </button>
+      )}
     </CommandItem>
-  );
+    );
+  };
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/frontend/src/components/landing/RecordingModal.tsx
+++ b/frontend/src/components/landing/RecordingModal.tsx
@@ -17,17 +17,22 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { AlertTriangle, CheckCircle, ChevronDown } from "lucide-react";
+import { AlertTriangle, CheckCircle, ChevronDown, Disc } from "lucide-react";
 import CameraConfiguration, {
   CameraConfig,
 } from "@/components/recording/CameraConfiguration";
 import { useHfAuth } from "@/contexts/HfAuthContext";
 import { RobotRecord } from "@/hooks/useRobots";
+import { ResumeDatasetInfo } from "@/pages/Landing";
 
 interface RecordingModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   robot: RobotRecord | null;
+  resumeMode?: boolean;
+  resumeInfo?: ResumeDatasetInfo | null;
+  episodeTarget?: number | null;
+  setEpisodeTarget?: (value: number | null) => void;
   datasetName: string;
   setDatasetName: (value: string) => void;
   singleTask: string;
@@ -50,6 +55,10 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
   open,
   onOpenChange,
   robot,
+  resumeMode = false,
+  resumeInfo = null,
+  episodeTarget = null,
+  setEpisodeTarget,
   datasetName,
   setDatasetName,
   singleTask,
@@ -69,7 +78,17 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
 }) => {
   const { auth } = useHfAuth();
 
-  const canStart = !!robot && robot.is_clean;
+  const configuredCameraNames = cameras.map((c) => c.name);
+  const missingCameras = resumeInfo
+    ? resumeInfo.cameras.filter((c) => !configuredCameraNames.includes(c))
+    : [];
+  const extraCameras = resumeInfo
+    ? configuredCameraNames.filter((c) => !resumeInfo.cameras.includes(c))
+    : [];
+  const camerasMatch = missingCameras.length === 0 && extraCameras.length === 0;
+  const setupOk = !resumeMode || !resumeInfo || camerasMatch;
+
+  const canStart = !!robot && robot.is_clean && setupOk;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -81,7 +100,7 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
             </div>
           </div>
           <DialogTitle className="text-white text-center text-2xl font-bold">
-            Configure Recording
+            {resumeMode ? "Continue Recording" : "Configure Recording"}
           </DialogTitle>
         </DialogHeader>
         <div className="space-y-6 py-4">
@@ -124,6 +143,84 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
               <h3 className="text-lg font-semibold text-white border-b border-gray-700 pb-2">
                 Dataset Configuration
               </h3>
+              {resumeMode && (
+                <Alert className="bg-blue-900/40 border-blue-700 text-blue-100">
+                  <Disc className="h-4 w-4" />
+                  <AlertDescription>
+                    New episodes will be appended to{" "}
+                    <strong className="font-mono">{datasetName}</strong>
+                    {resumeInfo && (
+                      <> ({resumeInfo.numEpisodes} episodes so far)</>
+                    )}
+                    . The setup must match the original recording exactly.
+                  </AlertDescription>
+                </Alert>
+              )}
+              {resumeMode && resumeInfo && (
+                <div className="rounded-lg border border-gray-700 bg-gray-800/60 p-3 space-y-2">
+                  <p className="text-sm font-medium text-gray-200">
+                    Required setup (from the dataset)
+                  </p>
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 text-xs">
+                    <div className="rounded bg-gray-800 border border-gray-700 px-2 py-1.5">
+                      <span className="text-gray-500 block">Robot type</span>
+                      <span className="text-gray-200 font-mono">
+                        {resumeInfo.robotType}
+                      </span>
+                    </div>
+                    <div className="rounded bg-gray-800 border border-gray-700 px-2 py-1.5">
+                      <span className="text-gray-500 block">FPS</span>
+                      <span className="text-gray-200 font-mono">
+                        {resumeInfo.fps}
+                      </span>
+                    </div>
+                    <div
+                      className={`rounded px-2 py-1.5 border ${
+                        camerasMatch
+                          ? "bg-gray-800 border-gray-700"
+                          : "bg-red-900/40 border-red-700"
+                      }`}
+                    >
+                      <span className="text-gray-500 block">Cameras</span>
+                      <span
+                        className={`font-mono ${camerasMatch ? "text-gray-200" : "text-red-300"}`}
+                      >
+                        {resumeInfo.cameras.join(", ") || "none"}
+                      </span>
+                    </div>
+                  </div>
+                  {!camerasMatch && (
+                    <Alert className="bg-red-900/40 border-red-700 text-red-100">
+                      <AlertTriangle className="h-4 w-4" />
+                      <AlertDescription className="text-xs">
+                        Camera setup doesn&apos;t match the dataset.
+                        {missingCameras.length > 0 && (
+                          <>
+                            {" "}
+                            Missing:{" "}
+                            <strong className="font-mono">
+                              {missingCameras.join(", ")}
+                            </strong>
+                            .
+                          </>
+                        )}
+                        {extraCameras.length > 0 && (
+                          <>
+                            {" "}
+                            Not in the dataset:{" "}
+                            <strong className="font-mono">
+                              {extraCameras.join(", ")}
+                            </strong>
+                            .
+                          </>
+                        )}{" "}
+                        Rename or adjust your cameras below to match, then the
+                        button will unlock.
+                      </AlertDescription>
+                    </Alert>
+                  )}
+                </div>
+              )}
               <div className="grid grid-cols-1 gap-4">
                 <div className="space-y-2">
                   <Label
@@ -135,20 +232,24 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
                   <Input
                     id="datasetName"
                     value={datasetName}
+                    disabled={resumeMode}
                     onChange={(e) =>
                       setDatasetName(
                         e.target.value.replace(/[^A-Za-z0-9._-]/g, "_")
                       )
                     }
                     placeholder="my_dataset"
-                    className="bg-gray-800 border-gray-700 text-white"
+                    className="bg-gray-800 border-gray-700 text-white disabled:opacity-60"
                   />
-                  <p className="text-xs text-gray-500">
-                    Letters, numbers, <code>.</code> <code>_</code>{" "}
-                    <code>-</code> only — other characters become{" "}
-                    <code>_</code>.
-                  </p>
+                  {!resumeMode && (
+                    <p className="text-xs text-gray-500">
+                      Letters, numbers, <code>.</code> <code>_</code>{" "}
+                      <code>-</code> only — other characters become{" "}
+                      <code>_</code>.
+                    </p>
+                  )}
                   {datasetName &&
+                    !resumeMode &&
                     (auth.status === "authenticated" ? (
                       <p className="text-xs text-gray-500">
                         Will be saved as{" "}
@@ -177,23 +278,46 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
                     className="bg-gray-800 border-gray-700 text-white"
                   />
                 </div>
-                <div className="space-y-2">
-                  <Label
-                    htmlFor="numEpisodes"
-                    className="text-sm font-medium text-gray-300"
-                  >
-                    Number of Episodes
-                  </Label>
-                  <NumberInput
-                    id="numEpisodes"
-                    min="1"
-                    max="100"
-                    value={numEpisodes}
-                    onChange={(v) => {
-                      if (v !== undefined) setNumEpisodes(v);
-                    }}
-                    className="bg-gray-800 border-gray-700 text-white"
-                  />
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="numEpisodes"
+                      className="text-sm font-medium text-gray-300"
+                    >
+                      {resumeMode ? "Episodes to add" : "Number of Episodes"}
+                    </Label>
+                    <NumberInput
+                      id="numEpisodes"
+                      min="1"
+                      max="100"
+                      value={numEpisodes}
+                      onChange={(v) => {
+                        if (v !== undefined) setNumEpisodes(v);
+                      }}
+                      className="bg-gray-800 border-gray-700 text-white"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="episodeTarget"
+                      className="text-sm font-medium text-gray-300"
+                    >
+                      Episode goal (optional)
+                    </Label>
+                    <NumberInput
+                      id="episodeTarget"
+                      min="1"
+                      value={episodeTarget ?? undefined}
+                      onChange={(v) => {
+                        setEpisodeTarget?.(v ?? null);
+                      }}
+                      className="bg-gray-800 border-gray-700 text-white"
+                    />
+                    <p className="text-xs text-gray-500">
+                      Total episodes you aim for across all sessions — shows
+                      progress in the dataset list.
+                    </p>
+                  </div>
                 </div>
                 <div className="grid grid-cols-2 gap-4">
                   <div className="space-y-2">
@@ -286,7 +410,7 @@ const RecordingModal: React.FC<RecordingModalProps> = ({
               disabled={!canStart}
               className="w-full sm:w-auto bg-red-500 hover:bg-red-600 text-white px-10 py-6 text-lg transition-all shadow-md shadow-red-500/30 hover:shadow-lg hover:shadow-red-500/40 disabled:opacity-40 disabled:cursor-not-allowed"
             >
-              Start Recording
+              {resumeMode ? "Resume Recording" : "Start Recording"}
             </Button>
             <Button
               onClick={() => onOpenChange(false)}

--- a/frontend/src/lib/episodeTargets.ts
+++ b/frontend/src/lib/episodeTargets.ts
@@ -1,0 +1,36 @@
+const STORAGE_KEY = "lelab-episode-targets";
+
+type TargetMap = Record<string, number>;
+
+function readMap(): TargetMap {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as TargetMap) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeMap(map: TargetMap) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // localStorage unavailable (private mode, etc.) — targets are a comfort
+    // feature, silently skip.
+  }
+}
+
+export function getEpisodeTarget(repoId: string): number | null {
+  const value = readMap()[repoId];
+  return typeof value === "number" && value > 0 ? value : null;
+}
+
+export function setEpisodeTarget(repoId: string, target: number | null) {
+  const map = readMap();
+  if (target && target > 0) {
+    map[repoId] = target;
+  } else {
+    delete map[repoId];
+  }
+  writeMap(map);
+}

--- a/frontend/src/lib/replayApi.ts
+++ b/frontend/src/lib/replayApi.ts
@@ -7,6 +7,7 @@ export interface DatasetItem {
   last_modified: string | null;
   private: boolean;
   source: DatasetSource;
+  num_episodes?: number | null;
 }
 
 export async function listDatasets(

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -12,13 +12,23 @@ import JobsSection from "@/components/jobs/JobsSection";
 
 import UsageInstructionsModal from "@/components/landing/UsageInstructionsModal";
 import { useHfAuth } from "@/contexts/HfAuthContext";
+import { useApi } from "@/contexts/ApiContext";
 import { useRobots } from "@/hooks/useRobots";
 import { useDatasets } from "@/hooks/useDatasets";
 import { DatasetItem } from "@/lib/replayApi";
+import { getEpisodeTarget } from "@/lib/episodeTargets";
 import { CameraConfig } from "@/components/recording/CameraConfiguration";
 import { isHostedSpace } from "@/lib/isHostedSpace";
 
 const ON_SPACE = isHostedSpace();
+
+export interface ResumeDatasetInfo {
+  fps: number;
+  cameras: string[];
+  robotType: string;
+  numEpisodes: number;
+  task: string | null;
+}
 
 const Landing = () => {
   const [showUsageModal, setShowUsageModal] = useState(ON_SPACE);
@@ -45,6 +55,10 @@ const Landing = () => {
   const [resetTimeS, setResetTimeS] = useState(15);
   const [streamingEncoding, setStreamingEncoding] = useState(true);
   const [cameras, setCameras] = useState<CameraConfig[]>([]);
+  const [resumeMode, setResumeMode] = useState(false);
+  const [resumeInfo, setResumeInfo] = useState<ResumeDatasetInfo | null>(null);
+  const [episodeTarget, setEpisodeTargetState] = useState<number | null>(null);
+  const { baseUrl, fetchWithHeaders } = useApi();
 
   const releaseStreamsRef = useRef<(() => void) | null>(null);
 
@@ -80,6 +94,11 @@ const Landing = () => {
 
   const handleRecordingModalClose = (open: boolean) => {
     setShowRecordingModal(open);
+    if (!open && resumeMode) {
+      setResumeMode(false);
+      setResumeInfo(null);
+      setDatasetName("");
+    }
     if (!open && releaseStreamsRef.current) {
       console.log("🧹 Modal closed: Releasing camera streams");
       releaseStreamsRef.current();
@@ -118,8 +137,47 @@ const Landing = () => {
   };
 
   const handleCreateDataset = (name: string) => {
+    setResumeMode(false);
+    setEpisodeTargetState(null);
     setDatasetName(name);
     openRecordingModal();
+  };
+
+  const handleResumeDataset = async (item: DatasetItem) => {
+    setResumeMode(true);
+    setDatasetName(item.repo_id);
+    setResumeInfo(null);
+    setEpisodeTargetState(getEpisodeTarget(item.repo_id));
+    openRecordingModal();
+    try {
+      const response = await fetchWithHeaders(`${baseUrl}/dataset-info`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ dataset_repo_id: item.repo_id }),
+      });
+      const info = await response.json();
+      if (!info.success) return;
+      const cameras = (info.features ?? [])
+        .filter((f: string) => f.startsWith("observation.images."))
+        .map((f: string) => f.split(".").pop() as string);
+      const tasks: string[] = info.tasks ?? [];
+      const task =
+        tasks.length > 0
+          ? tasks[tasks.length - 1]
+          : info.single_task && info.single_task !== "Unknown task"
+            ? info.single_task
+            : null;
+      setResumeInfo({
+        fps: info.fps ?? 30,
+        cameras,
+        robotType: info.robot_type ?? "unknown",
+        numEpisodes: info.num_episodes ?? 0,
+        task,
+      });
+      if (task) setSingleTask(task);
+    } catch (e) {
+      console.warn("Could not load dataset info for resume:", e);
+    }
   };
 
   const handleStartRecording = async () => {
@@ -149,8 +207,9 @@ const Landing = () => {
       return;
     }
 
-    const datasetRepoId =
-      auth.status === "authenticated"
+    const datasetRepoId = resumeMode
+      ? datasetName
+      : auth.status === "authenticated"
         ? `${auth.username}/${datasetName}`
         : datasetName;
 
@@ -207,12 +266,13 @@ const Landing = () => {
       num_episodes: numEpisodes,
       episode_time_s: episodeTimeS,
       reset_time_s: resetTimeS,
-      fps: 30,
+      fps: resumeMode && resumeInfo ? resumeInfo.fps : 30,
       video: true,
       push_to_hub: false,
-      resume: false,
+      resume: resumeMode,
       streaming_encoding: streamingEncoding,
       cameras: cameraDict,
+      episode_target: episodeTarget,
     };
 
     setShowRecordingModal(false);
@@ -249,6 +309,7 @@ const Landing = () => {
                 datasets={datasets}
                 loading={datasetsLoading}
                 onPickExisting={handlePickExisting}
+                onResumeExisting={handleResumeDataset}
                 onOpenCustom={handleOpenCustom}
                 onCreateNew={handleCreateDataset}
               >
@@ -297,6 +358,10 @@ const Landing = () => {
         open={showRecordingModal}
         onOpenChange={handleRecordingModalClose}
         robot={selectedRecord}
+        resumeMode={resumeMode}
+        resumeInfo={resumeInfo}
+        episodeTarget={episodeTarget}
+        setEpisodeTarget={setEpisodeTargetState}
         datasetName={datasetName}
         setDatasetName={setDatasetName}
         singleTask={singleTask}

--- a/frontend/src/pages/Recording.tsx
+++ b/frontend/src/pages/Recording.tsx
@@ -25,6 +25,7 @@ import {
   playResetStartCue,
   playAutoAdvanceWarning,
 } from "@/lib/recordingAudio";
+import { setEpisodeTarget } from "@/lib/episodeTargets";
 import { useApi } from "@/contexts/ApiContext";
 import {
   AlertDialog,
@@ -52,6 +53,7 @@ interface RecordingConfig {
   push_to_hub: boolean;
   resume: boolean;
   streaming_encoding: boolean;
+  episode_target?: number | null;
 }
 
 type Phase = "preparing" | "recording" | "resetting" | "completed";
@@ -225,6 +227,12 @@ const Recording = () => {
       const data = await response.json();
 
       if (response.ok) {
+        if (recordingConfig.episode_target) {
+          setEpisodeTarget(
+            data.dataset_id ?? recordingConfig.dataset_repo_id,
+            recordingConfig.episode_target,
+          );
+        }
         setRecordingSessionStarted(true);
         toast({
           title: "Recording Started",

--- a/lelab/datasets.py
+++ b/lelab/datasets.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 import os
 from datetime import UTC, datetime
@@ -42,6 +43,17 @@ def _dir_mtime_iso(path: Path) -> str | None:
         ts = path.stat().st_mtime
         return datetime.fromtimestamp(ts, tz=UTC).isoformat()
     except OSError:
+        return None
+
+
+def _dataset_episode_count(path: Path) -> int | None:
+    """Episode count from <dir>/meta/info.json, without loading the dataset."""
+    try:
+        with open(path / "meta" / "info.json", encoding="utf-8") as f:
+            info = json.load(f)
+        count = info.get("total_episodes")
+        return int(count) if count is not None else None
+    except (OSError, ValueError, TypeError):
         return None
 
 
@@ -76,6 +88,7 @@ def list_local_datasets() -> list[dict[str, Any]]:
                     "repo_id": top.name,
                     "last_modified": _dir_mtime_iso(top),
                     "private": False,
+                    "num_episodes": _dataset_episode_count(top),
                 }
             )
             continue
@@ -97,6 +110,7 @@ def list_local_datasets() -> list[dict[str, Any]]:
                         "repo_id": f"{top.name}/{sub.name}",
                         "last_modified": _dir_mtime_iso(sub),
                         "private": False,
+                        "num_episodes": _dataset_episode_count(sub),
                     }
                 )
 
@@ -150,6 +164,7 @@ def list_all_datasets() -> list[dict[str, Any]]:
         if rid in merged:
             existing = merged[rid]
             existing["source"] = "both"
+            existing["num_episodes"] = item.get("num_episodes")
             # Keep the newer timestamp; ISO strings sort lexically.
             a = existing.get("last_modified") or ""
             b = item.get("last_modified") or ""

--- a/lelab/record.py
+++ b/lelab/record.py
@@ -470,11 +470,16 @@ def handle_get_dataset_info(request: DatasetInfoRequest) -> dict[str, Any]:
         from lerobot.datasets import LeRobotDataset
 
         dataset = LeRobotDataset(request.dataset_repo_id)
+        try:
+            tasks = [str(t) for t in dataset.meta.tasks.index]
+        except Exception:
+            tasks = []
         return {
             "success": True,
             "dataset_repo_id": request.dataset_repo_id,
             "num_episodes": dataset.num_episodes,
             "single_task": getattr(dataset.meta, "single_task", "Unknown task"),
+            "tasks": tasks,
             "fps": dataset.fps,
             "features": list(dataset.features.keys()),
             "total_frames": dataset.num_frames,
@@ -597,9 +602,17 @@ def record_with_web_events(cfg: RecordConfig, web_events: dict) -> LeRobotDatase
 
     if cfg.resume:
         num_cameras = len(robot.cameras) if hasattr(robot, "cameras") else 0
+        # LeRobotDataset.resume() refuses root=None (it would write into the
+        # revision-safe Hub snapshot cache), so resolve the same default local
+        # directory that LeRobotDataset.create() uses.
+        resume_root = cfg.dataset.root
+        if resume_root is None:
+            from lerobot.utils.constants import HF_LEROBOT_HOME
+
+            resume_root = HF_LEROBOT_HOME / cfg.dataset.repo_id
         dataset = LeRobotDataset.resume(
             cfg.dataset.repo_id,
-            root=cfg.dataset.root,
+            root=resume_root,
             batch_encoding_size=cfg.dataset.video_encoding_batch_size,
             rgb_encoder=cfg.dataset.rgb_encoder,
             depth_encoder=cfg.dataset.depth_encoder,


### PR DESCRIPTION
## Related issue

Relates to issues #11,  PR #14  already proposes an implementation via a dedicated Edit Dataset page; this PR takes a different approach — resuming directly from the existing dataset-picker/create flow via a new "Resume" action, plus a fix for `LeRobotDataset.resume(root=None)` being rejected by current `lerobot`. Happy to reconcile with #14's design if that's the preferred direction — flagging the overlap so it's visible rather than duplicated silently.

Recording a full dataset rarely happens in one sitting. Before this, adding more episodes to an existing dataset later meant starting a brand new one and merging them by hand — nothing stopped you from silently mixing sessions with different FPS, cameras, or task wording into a broken combined dataset.

## What changed

- `DatasetPicker` lists existing local/Hub datasets with their episode count, and offers a "Resume" action next to "Create new".
- Resuming pre-fills FPS, cameras, robot type, and the last task description from the dataset's own metadata (via a new `tasks` field on `/dataset-info`), and **blocks recording** if the current camera/robot setup doesn't match what the dataset was originally recorded with — this is exactly the mismatch that used to fail silently.
- An optional episode-count target (stored in `localStorage`, not the dataset itself) drives a progress bar across sessions, e.g. "14 / 45 episodes".
- Backend fix: `LeRobotDataset.resume()` was being called with `root=None`, which current `lerobot` rejects. Now resolves the same default local directory `LeRobotDataset.create()` uses.

```mermaid
sequenceDiagram
    participant U as User
    participant L as Landing page
    participant API as LeLab backend
    participant DS as LeRobotDataset

    U->>L: Click "Resume" on a dataset
    L->>API: POST /dataset-info {repo_id}
    API->>DS: LeRobotDataset(repo_id)
    DS-->>API: fps, cameras, robot_type, tasks
    API-->>L: pre-fill form
    Note over L: Blocks start if current setup mismatches
    U->>L: Confirm, start recording
    L->>API: POST /start-recording {resume: true, repo_id}
    API->>DS: LeRobotDataset.resume(repo_id, root=resolved_root)
    DS-->>API: existing episodes preserved
    API-->>L: new episodes appended after the last one
```

## Testing

Validated end-to-end on the physical SO-101: episodes appended to a 5-episode dataset across two separate sessions on different days, episode count and video/frame continuity confirmed on the Hub afterward.