### PR TITLE
fix(update): only flag an update when the install is behind

### DIFF
--- a/lelab/update.py
+++ b/lelab/update.py
@@ -185,11 +185,19 @@ def _compute_status() -> dict[str, Any]:
         base.commits_behind = 0
         return base.model_dump()
 
+    # compare(base=installed, head=latest) reports how the repo relates to the
+    # installed commit. Only status "ahead" means the repo has strictly newer
+    # commits the install can fast-forward to — the one case worth a nudge.
+    # "behind" (the install sits ahead of the default branch) and "diverged"
+    # (history rewritten / force-push) must not nag: the in-place --force
+    # reinstall would throw away those local commits. If the compare is
+    # unavailable (e.g. the installed commit is no longer in the repo), stay
+    # silent rather than guess.
     compare = _github_json(f"/repos/{owner}/{repo}/compare/{current}...{latest}")
     if isinstance(compare, dict):
         base.commits_behind = compare.get("ahead_by")
         base.compare_url = compare.get("html_url")
-    base.update_available = True
+        base.update_available = compare.get("status") == "ahead"
     return base.model_dump()
 
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -119,7 +119,11 @@ def test_check_update_available(monkeypatch):
         if path.endswith("/commits/HEAD"):
             return {"sha": "def456"}
         if "/compare/" in path:
-            return {"ahead_by": 7, "html_url": "https://github.com/huggingface/leLab/compare/abc123...def456"}
+            return {
+                "status": "ahead",
+                "ahead_by": 7,
+                "html_url": "https://github.com/huggingface/leLab/compare/abc123...def456",
+            }
         return None
 
     monkeypatch.setattr(update, "_github_json", fake_github)
@@ -130,6 +134,69 @@ def test_check_update_available(monkeypatch):
     assert status["compare_url"].endswith("abc123...def456")
     assert "git+https://github.com/huggingface/leLab.git" in status["update_command"]
     assert status["can_auto_update"] is True
+
+
+def test_check_diverged_does_not_nag(monkeypatch):
+    """A rewritten/force-pushed default branch reads as 'diverged'. Offering an
+    in-place --force reinstall there would silently discard the local commits,
+    so we must not flag an update."""
+    monkeypatch.setattr(
+        update,
+        "get_installed_source",
+        lambda: {"commit": "abc123", "owner": "huggingface", "repo": "leLab"},
+    )
+
+    def fake_github(path: str):
+        if path.endswith("/commits/HEAD"):
+            return {"sha": "def456"}
+        if "/compare/" in path:
+            return {"status": "diverged", "ahead_by": 3, "behind_by": 2}
+        return None
+
+    monkeypatch.setattr(update, "_github_json", fake_github)
+    status = update.check_for_update()
+    assert status["update_available"] is False
+
+
+def test_check_install_ahead_of_remote_does_not_nag(monkeypatch):
+    """If the installed commit is ahead of the default branch, compare reports
+    'behind' (head=latest is behind base=installed). There is nothing to update
+    to, so stay silent."""
+    monkeypatch.setattr(
+        update,
+        "get_installed_source",
+        lambda: {"commit": "abc123", "owner": "huggingface", "repo": "leLab"},
+    )
+
+    def fake_github(path: str):
+        if path.endswith("/commits/HEAD"):
+            return {"sha": "def456"}
+        if "/compare/" in path:
+            return {"status": "behind", "ahead_by": 0, "behind_by": 5}
+        return None
+
+    monkeypatch.setattr(update, "_github_json", fake_github)
+    status = update.check_for_update()
+    assert status["update_available"] is False
+
+
+def test_check_compare_unavailable_does_not_nag(monkeypatch):
+    """HEAD differs but the compare call fails (e.g. the installed commit is no
+    longer in the repo). Without proof the install is behind, stay silent."""
+    monkeypatch.setattr(
+        update,
+        "get_installed_source",
+        lambda: {"commit": "abc123", "owner": "huggingface", "repo": "leLab"},
+    )
+
+    def fake_github(path: str):
+        if path.endswith("/commits/HEAD"):
+            return {"sha": "def456"}
+        return None  # compare unreachable
+
+    monkeypatch.setattr(update, "_github_json", fake_github)
+    status = update.check_for_update()
+    assert status["update_available"] is False
 
 
 def test_check_github_unreachable_is_silent(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

The update notifier flagged "update available" whenever the repo HEAD differed
from the installed commit, in **either** direction. So an install that was ahead
of the default branch (a dev build) or on a branch that had diverged (a
force-push or rewritten history) still got nagged to update, and the in-place
`--force` reinstall the button offers would have discarded those local commits.

## The cause

`_compute_status()` compared the installed commit to the repo HEAD and set
`update_available = True` for any difference:

```python
compare = _github_json(f"/repos/{owner}/{repo}/compare/{current}...{latest}")
if isinstance(compare, dict):
    base.commits_behind = compare.get("ahead_by")
    base.compare_url = compare.get("html_url")
base.update_available = True   # <- true for ahead / behind / diverged alike
```

GitHub's `compare(base=installed, head=latest)` already classifies the
relationship in its `status` field (`ahead`, `behind`, `diverged`, `identical`),
but the code ignored it.

## The fix

Gate on `status == "ahead"`, the one case where the repo has strictly newer
commits the install can fast-forward to:

```python
if isinstance(compare, dict):
    base.commits_behind = compare.get("ahead_by")
    base.compare_url = compare.get("html_url")
    base.update_available = compare.get("status") == "ahead"
```

`behind` (the install is ahead of the default branch) and `diverged` now stay
silent, as does an unavailable compare (for instance when the installed commit is
no longer in the repo), rather than guessing.

## Before / after

| Install relationship to default branch | compare status | Before | After |
|---|---|---|---|
| Behind (normal, new commits upstream) | `ahead` | "update available" | "update available" (unchanged) |
| Up to date | `identical` | silent | silent (unchanged) |
| Ahead (dev build) | `behind` | **"update available", 0 commits behind** | silent |
| Diverged (force-push / rewritten history) | `diverged` | **"update available"** | silent |
| GitHub compare unreachable | — | **"update available"** | silent |

## Testing

Reproduced with unit tests that feed `_github_json` a canned compare response.
Three new tests (`diverged`, install-ahead, compare-unavailable) fail against the
current code and pass with the fix; the existing "update available" and
"up to date" cases still pass. `pytest tests/test_update.py`: 20 passed. ruff
check and ruff format green; pre-commit (mypy, bandit, typos) green.
