### PR TITLE
fix(inference): close the log file if inference fails to start

### DIFF
--- a/lelab/rollout.py
+++ b/lelab/rollout.py
@@ -266,6 +266,11 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
         # Claim the slot now so a concurrent caller losing the race sees us.
         inference_active = True
 
+    # Opened partway through setup; the stdout pump thread takes ownership once
+    # it starts. Tracked here so a failure before that hand-off can close it
+    # instead of leaking the file handle (which on Windows also keeps the log
+    # locked).
+    log_handle = None
     try:
         # `setup_follower_calibration_file` returns the basename without the
         # .json extension. We need that stripped form for `--robot.id`,
@@ -323,9 +328,14 @@ def handle_start_inference(request: InferenceRequest) -> dict[str, Any]:
             name="inference-stdout-pump",
             daemon=True,
         ).start()
+        log_handle = None  # pump thread owns and closes it from here on
     except Exception as exc:
         logger.exception("Failed to start inference")
-        # Subprocess never started — release the slot.
+        # Startup failed before the pump thread took over (most often Popen
+        # itself). Release the slot and close the log file if we opened it before
+        # failing, so the handle isn't leaked.
+        if log_handle is not None:
+            log_handle.close()
         with _state_lock:
             inference_active = False
         return {"success": False, "status_code": 500, "message": f"Failed to start inference: {exc}"}

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -263,6 +263,38 @@ def test_handle_start_inference_blocked_when_already_active(monkeypatch) -> None
     assert "already active" in result["message"]
 
 
+def test_handle_start_inference_closes_log_when_popen_fails(monkeypatch, tmp_path) -> None:
+    """If Popen fails after the log file is opened, the handle must be closed,
+    not leaked — on Windows a leaked handle also keeps the log file locked."""
+    from lelab import rollout
+
+    monkeypatch.setattr(rollout, "setup_follower_calibration_file", lambda cfg: "robot_a")
+    monkeypatch.setattr(rollout, "_resolve_policy_path", lambda ref: str(tmp_path / "model"))
+
+    opened: list = []
+    real_open = rollout.Path.open
+
+    def tracking_open(self, *args, **kwargs):
+        handle = real_open(self, *args, **kwargs)
+        opened.append(handle)
+        return handle
+
+    monkeypatch.setattr(rollout.Path, "open", tracking_open)
+
+    def boom(*args, **kwargs):
+        raise OSError("simulated Popen failure")
+
+    monkeypatch.setattr(rollout.subprocess, "Popen", boom)
+
+    result = rollout.handle_start_inference(_stub_request())
+
+    assert result["success"] is False
+    assert result["status_code"] == 500
+    assert opened, "expected the inference log file to have been opened"
+    assert all(handle.closed for handle in opened), "log handle leaked on Popen failure"
+    assert rollout.inference_active is False
+
+
 def test_classify_outcome_ok_warns_and_fails() -> None:
     from lelab.rollout import _classify_outcome
 


### PR DESCRIPTION
## What does this PR do?

`handle_start_inference` opens the rollout log file before it spawns the
inference subprocess, and the stdout-pump thread only takes ownership of that
handle once it starts. If anything in between raised — most commonly `Popen`
itself failing to launch the process — the `except` block released the inference
slot and returned a 500, but never closed the log file. That leaks the file
handle. On Windows it also keeps the just-created log file locked.

## The cause

```python
log_path = log_dir / f"{int(time.time())}.log"
log_handle = log_path.open("w", buffering=1)      # opened here
...
proc = subprocess.Popen(cmd, ...)                 # if this raises...
...
threading.Thread(target=_pump_stdout, args=(proc, log_handle), ...).start()
except Exception as exc:
    logger.exception("Failed to start inference")
    with _state_lock:
        inference_active = False
    return {...}                                  # ...log_handle is never closed
```

## The fix

Track the handle from before the `try`, hand ownership to the pump thread by
clearing the reference once the thread starts, and close it on the failure path
only when it is still ours (never opened, or already handed off, both stay safe):

```python
log_handle = None
try:
    ...
    log_handle = log_path.open("w", buffering=1)
    ...
    threading.Thread(target=_pump_stdout, args=(proc, log_handle), ...).start()
    log_handle = None            # pump thread owns and closes it from here on
except Exception as exc:
    logger.exception("Failed to start inference")
    if log_handle is not None:
        log_handle.close()       # opened before we failed — don't leak it
    with _state_lock:
        inference_active = False
    return {...}
```

## Before / after

Simulating a `Popen` failure (patch `subprocess.Popen` to raise):

- Before: `handle_start_inference` returns 500, but the log file opened moments
  earlier stays open until garbage collection; on Windows the file is locked.
- After: the handle is closed on the way out. The slot is still released and the
  same 500 is returned.

## Testing

New test `test_handle_start_inference_closes_log_when_popen_fails` patches
`Popen` to raise and asserts the opened log handle ends up `closed` and the
inference slot is released. It fails against the current code and passes with the
fix. `pytest tests/test_rollout.py`: 23 passed. ruff check and ruff format green;
pre-commit (mypy, bandit, typos) green.