### PR TITLE
feat(onboarding): Add a guided onboarding tour for newcomers

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import UpdateNotice from "@/components/UpdateNotice";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { ApiProvider } from "./contexts/ApiContext";
 import { HfAuthProvider } from "./contexts/HfAuthContext";
+import { OnboardingProvider } from "./contexts/OnboardingContext";
 
 const queryClient = new QueryClient();
 
@@ -33,24 +34,26 @@ function App() {
               <UrdfProvider>
                 <DragAndDropProvider>
                   <BrowserRouter>
-                    <SingleTabGuard>
-                      <TeleopStopNotice />
-                      <UpdateNotice />
-                      <Routes>
-                        <Route path="/" element={<Landing />} />
-                        <Route path="/teleoperation" element={<Teleoperation />} />
-                        <Route path="/recording" element={<Recording />} />
-                        <Route path="/upload" element={<Upload />} />
-                        <Route path="/training" element={<Training />} />
-                        <Route path="/training/:jobId" element={<Training />} />
-                        <Route path="/inference" element={<Inference />} />
-                        <Route path="/calibration" element={<Calibration />} />
-                        <Route path="/edit-dataset" element={<EditDataset />} />
+                    <OnboardingProvider>
+                      <SingleTabGuard>
+                        <TeleopStopNotice />
+                        <UpdateNotice />
+                        <Routes>
+                          <Route path="/" element={<Landing />} />
+                          <Route path="/teleoperation" element={<Teleoperation />} />
+                          <Route path="/recording" element={<Recording />} />
+                          <Route path="/upload" element={<Upload />} />
+                          <Route path="/training" element={<Training />} />
+                          <Route path="/training/:jobId" element={<Training />} />
+                          <Route path="/inference" element={<Inference />} />
+                          <Route path="/calibration" element={<Calibration />} />
+                          <Route path="/edit-dataset" element={<EditDataset />} />
 
-                        <Route path="*" element={<NotFound />} />
-                      </Routes>
-                    </SingleTabGuard>
-                    <Toaster />
+                          <Route path="*" element={<NotFound />} />
+                        </Routes>
+                      </SingleTabGuard>
+                      <Toaster />
+                    </OnboardingProvider>
                   </BrowserRouter>
                 </DragAndDropProvider>
               </UrdfProvider>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,8 +34,8 @@ function App() {
               <UrdfProvider>
                 <DragAndDropProvider>
                   <BrowserRouter>
-                    <OnboardingProvider>
-                      <SingleTabGuard>
+                    <SingleTabGuard>
+                      <OnboardingProvider>
                         <TeleopStopNotice />
                         <UpdateNotice />
                         <Routes>
@@ -51,9 +51,9 @@ function App() {
 
                           <Route path="*" element={<NotFound />} />
                         </Routes>
-                      </SingleTabGuard>
-                      <Toaster />
-                    </OnboardingProvider>
+                      </OnboardingProvider>
+                    </SingleTabGuard>
+                    <Toaster />
                   </BrowserRouter>
                 </DragAndDropProvider>
               </UrdfProvider>

--- a/frontend/src/components/SingleTabGuard.tsx
+++ b/frontend/src/components/SingleTabGuard.tsx
@@ -108,9 +108,14 @@ const SingleTabGuard = ({ children }: { children: ReactNode }) => {
     recompute();
   }, [recompute]);
 
+  // A non-primary tab renders only the blocker, not `children`. Anything the
+  // app mounts as a descendant (a Radix modal that sets `pointer-events: none`
+  // on `body`, the onboarding welcome dialog and `?` launcher) would otherwise
+  // sit behind this overlay and, in the modal case, kill the "Use this tab"
+  // button along with the rest of the page.
   return (
     <>
-      {children}
+      {isPrimary && children}
       {!isPrimary && (
         <div
           className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/80 backdrop-blur-sm"

--- a/frontend/src/components/jobs/JobsSection.tsx
+++ b/frontend/src/components/jobs/JobsSection.tsx
@@ -245,7 +245,7 @@ const JobsSection: React.FC = () => {
     untrackedHubInactive.length;
 
   return (
-    <section className="space-y-6">
+    <section className="space-y-6" data-tour="jobs-section">
       <div className="flex items-center justify-between gap-3">
         <h2 className="text-lg font-semibold text-white">Jobs</h2>
         <div className="flex items-center gap-2">

--- a/frontend/src/components/landing/LandingTopBar.tsx
+++ b/frontend/src/components/landing/LandingTopBar.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import HfAuthChip from "./HfAuthChip";
+import TourLauncher from "@/components/onboarding/TourLauncher";
 
 const LandingTopBar: React.FC = () => {
   return (
@@ -15,7 +16,10 @@ const LandingTopBar: React.FC = () => {
             LeLab
           </span>
         </div>
-        <HfAuthChip />
+        <div className="flex items-center gap-2">
+          <TourLauncher variant="inline" />
+          <HfAuthChip />
+        </div>
       </div>
     </header>
   );

--- a/frontend/src/components/landing/RobotTile.tsx
+++ b/frontend/src/components/landing/RobotTile.tsx
@@ -47,7 +47,7 @@ const RobotTile: React.FC<RobotTileProps> = ({
   return (
     <div className="bg-gray-800 rounded-lg border border-gray-700 p-3 flex flex-col gap-2 relative">
       <div className="flex items-center gap-2">
-        <div className="flex-1 min-w-0">
+        <div className="flex-1 min-w-0" data-tour="robot-selector">
           <RobotSelector
             selectedName={selectedName}
             availableNames={availableNames}
@@ -75,6 +75,7 @@ const RobotTile: React.FC<RobotTileProps> = ({
                   className="h-8 w-8 text-gray-300 hover:text-white"
                   onClick={() => onConfigure(robot.name)}
                   aria-label="Configure"
+                  data-tour="robot-configure"
                 >
                   <Settings className="w-4 h-4" />
                 </Button>
@@ -102,7 +103,7 @@ const RobotTile: React.FC<RobotTileProps> = ({
       {robot && (
         <Tooltip>
           <TooltipTrigger asChild>
-            <div className="w-full">
+            <div className="w-full" data-tour="robot-teleop">
               <Button
                 onClick={() => onTeleop(robot)}
                 disabled={teleopDisabled}

--- a/frontend/src/components/onboarding/SpotlightOverlay.tsx
+++ b/frontend/src/components/onboarding/SpotlightOverlay.tsx
@@ -104,7 +104,7 @@ const SpotlightOverlay: React.FC = () => {
       ) : (
         <div className="absolute inset-0 bg-black/60" />
       )}
-      <TourCard rect={hasRect ? rect : null} />
+      <TourCard key={currentStep.id} rect={hasRect ? rect : null} />
     </div>,
     document.body
   );

--- a/frontend/src/components/onboarding/SpotlightOverlay.tsx
+++ b/frontend/src/components/onboarding/SpotlightOverlay.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useLayoutEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { useOnboarding } from "@/contexts/OnboardingContext";
+import TourCard from "@/components/onboarding/TourCard";
+
+// Padding around the highlighted element, in px.
+const PAD = 8;
+// How long to wait for a step's target to appear (e.g. after a route change)
+// before falling back to a centered card so the tour never blocks.
+const MOUNT_TIMEOUT_MS = 3000;
+
+const SpotlightOverlay: React.FC = () => {
+  const { isActive, currentStep, stop } = useOnboarding();
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  // Becomes true once we've either located the target or given up (fallback).
+  const [ready, setReady] = useState(false);
+
+  const stepId = currentStep?.id ?? null;
+  const target = currentStep?.target ?? null;
+
+  // Locate the step's target, tracking it across scroll/resize/layout shifts.
+  // Re-runs whenever the step changes.
+  useLayoutEffect(() => {
+    setReady(false);
+    setRect(null);
+    if (!isActive || !stepId) return;
+
+    // Centered steps (welcome/done) have no target.
+    if (!target) {
+      setReady(true);
+      return;
+    }
+
+    let raf = 0;
+    let observer: ResizeObserver | null = null;
+    let tracked: Element | null = null;
+    const startedAt = performance.now();
+
+    const measure = () => {
+      if (tracked) setRect(tracked.getBoundingClientRect());
+    };
+
+    const attachTrackers = (el: Element) => {
+      tracked = el;
+      measure();
+      setReady(true);
+      window.addEventListener("scroll", measure, true);
+      window.addEventListener("resize", measure);
+      observer = new ResizeObserver(measure);
+      observer.observe(el);
+    };
+
+    const poll = () => {
+      const el = document.querySelector(`[data-tour="${target}"]`);
+      if (el) {
+        attachTrackers(el);
+        return;
+      }
+      if (performance.now() - startedAt > MOUNT_TIMEOUT_MS) {
+        // Target never mounted — show the copy centered rather than block.
+        setRect(null);
+        setReady(true);
+        return;
+      }
+      raf = requestAnimationFrame(poll);
+    };
+    poll();
+
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      window.removeEventListener("scroll", measure, true);
+      window.removeEventListener("resize", measure);
+      observer?.disconnect();
+    };
+  }, [isActive, stepId, target]);
+
+  // Esc leaves the tour from anywhere.
+  useEffect(() => {
+    if (!isActive) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") stop(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isActive, stop]);
+
+  if (!isActive || !currentStep || !ready) return null;
+
+  const hasRect = !!rect && rect.width > 0 && rect.height > 0;
+
+  return createPortal(
+    <div className="pointer-events-none fixed inset-0 z-40">
+      {hasRect ? (
+        <div
+          className="pointer-events-none absolute rounded-lg ring-2 ring-blue-400/80 transition-all duration-200"
+          style={{
+            top: rect!.top - PAD,
+            left: rect!.left - PAD,
+            width: rect!.width + PAD * 2,
+            height: rect!.height + PAD * 2,
+            boxShadow: "0 0 0 9999px rgba(0,0,0,0.6)",
+          }}
+        />
+      ) : (
+        <div className="absolute inset-0 bg-black/60" />
+      )}
+      <TourCard rect={hasRect ? rect : null} />
+    </div>,
+    document.body
+  );
+};
+
+export default SpotlightOverlay;

--- a/frontend/src/components/onboarding/SpotlightOverlay.tsx
+++ b/frontend/src/components/onboarding/SpotlightOverlay.tsx
@@ -42,6 +42,11 @@ const SpotlightOverlay: React.FC = () => {
 
     const attachTrackers = (el: Element) => {
       tracked = el;
+      // Bring the target on-screen if it's below the fold (e.g. the cameras or
+      // jobs step). "nearest" scrolls the minimum needed and does nothing when
+      // it's already visible; the scroll listener below keeps the cutout and
+      // card glued to it as the smooth scroll settles.
+      el.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "nearest" });
       measure();
       setReady(true);
       window.addEventListener("scroll", measure, true);

--- a/frontend/src/components/onboarding/SpotlightOverlay.tsx
+++ b/frontend/src/components/onboarding/SpotlightOverlay.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useLayoutEffect, useState } from "react";
 import { createPortal } from "react-dom";
+import { useLocation } from "react-router-dom";
 import { useOnboarding } from "@/contexts/OnboardingContext";
 import TourCard from "@/components/onboarding/TourCard";
 
@@ -11,6 +12,7 @@ const MOUNT_TIMEOUT_MS = 3000;
 
 const SpotlightOverlay: React.FC = () => {
   const { isActive, currentStep, stop } = useOnboarding();
+  const location = useLocation();
   const [rect, setRect] = useState<DOMRect | null>(null);
   // Becomes true once we've either located the target or given up (fallback).
   const [ready, setReady] = useState(false);
@@ -19,7 +21,8 @@ const SpotlightOverlay: React.FC = () => {
   const target = currentStep?.target ?? null;
 
   // Locate the step's target, tracking it across scroll/resize/layout shifts.
-  // Re-runs whenever the step changes.
+  // Re-runs whenever the step changes, and on route changes so a manual
+  // navigation away mid-step re-queries (rather than pinning a stale rect).
   useLayoutEffect(() => {
     setReady(false);
     setRect(null);
@@ -37,7 +40,15 @@ const SpotlightOverlay: React.FC = () => {
     const startedAt = performance.now();
 
     const measure = () => {
-      if (tracked) setRect(tracked.getBoundingClientRect());
+      if (!tracked) return;
+      // The element can leave the DOM under us (e.g. the user navigated away
+      // before this effect re-runs). Drop the spotlight instead of pinning it
+      // to a stale position.
+      if (!tracked.isConnected) {
+        setRect(null);
+        return;
+      }
+      setRect(tracked.getBoundingClientRect());
     };
 
     const attachTrackers = (el: Element) => {
@@ -77,7 +88,7 @@ const SpotlightOverlay: React.FC = () => {
       window.removeEventListener("resize", measure);
       observer?.disconnect();
     };
-  }, [isActive, stepId, target]);
+  }, [isActive, stepId, target, location.pathname]);
 
   // Esc leaves the tour from anywhere.
   useEffect(() => {

--- a/frontend/src/components/onboarding/TourCard.tsx
+++ b/frontend/src/components/onboarding/TourCard.tsx
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, useRef, useState } from "react";
-import { X } from "lucide-react";
+import { Check, Lock, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useOnboarding } from "@/contexts/OnboardingContext";
@@ -17,8 +17,17 @@ interface TourCardProps {
 }
 
 const TourCard: React.FC<TourCardProps> = ({ rect }) => {
-  const { currentStep, stepIndex, totalSteps, next, back, skipStep, stop } =
-    useOnboarding();
+  const {
+    currentStep,
+    stepIndex,
+    totalSteps,
+    currentComplete,
+    currentGated,
+    next,
+    back,
+    skipStep,
+    stop,
+  } = useOnboarding();
   const cardRef = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState({ w: CARD_W, h: 0 });
 
@@ -97,15 +106,31 @@ const TourCard: React.FC<TourCardProps> = ({ rect }) => {
       </button>
 
       <div className="p-4 pt-5">
-        <p className="mb-1 text-xs font-medium uppercase tracking-wide text-blue-400">
-          Step {stepIndex + 1} of {totalSteps}
-        </p>
+        <div className="mb-1 flex items-center gap-2">
+          <p className="text-xs font-medium uppercase tracking-wide text-blue-400">
+            Step {stepIndex + 1} of {totalSteps}
+          </p>
+          {currentComplete && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-green-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-400">
+              <Check className="h-3 w-3" />
+              Done
+            </span>
+          )}
+        </div>
         <h3 className="pr-6 text-base font-semibold text-white">
           {currentStep.title}
         </h3>
         <p className="mt-2 text-sm leading-relaxed text-gray-300">
           {currentStep.body}
         </p>
+
+        {currentGated && !currentComplete && (
+          <p className="mt-2 flex items-center gap-1.5 text-xs text-amber-400">
+            <Lock className="h-3 w-3 shrink-0" />
+            Finish the earlier step to unlock this. You can keep reading and move
+            on with Skip.
+          </p>
+        )}
 
         <div className="mt-4 flex items-center justify-between gap-2">
           <Button
@@ -131,9 +156,14 @@ const TourCard: React.FC<TourCardProps> = ({ rect }) => {
             <Button
               size="sm"
               onClick={next}
-              className="bg-blue-600 text-white hover:bg-blue-700"
+              className={cn(
+                "text-white",
+                currentComplete
+                  ? "bg-green-600 hover:bg-green-700"
+                  : "bg-blue-600 hover:bg-blue-700"
+              )}
             >
-              {isLast ? "Finish" : "Next"}
+              {isLast ? "Finish" : currentComplete ? "Continue" : "Next"}
             </Button>
           </div>
         </div>

--- a/frontend/src/components/onboarding/TourCard.tsx
+++ b/frontend/src/components/onboarding/TourCard.tsx
@@ -137,8 +137,8 @@ const TourCard: React.FC<TourCardProps> = ({ rect }) => {
         {currentGated && !currentComplete && (
           <p className="mt-2 flex items-center gap-1.5 text-xs text-amber-400">
             <Lock className="h-3 w-3 shrink-0" />
-            Finish the earlier step to unlock this. You can keep reading and move
-            on with Skip.
+            Finish the earlier step to unlock this, or continue with Next
+            whenever you like.
           </p>
         )}
 

--- a/frontend/src/components/onboarding/TourCard.tsx
+++ b/frontend/src/components/onboarding/TourCard.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Check, Lock, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -37,6 +37,13 @@ const TourCard: React.FC<TourCardProps> = ({ rect }) => {
       setSize({ w: r.width, h: r.height });
     }
   }, [currentStep?.id, rect]);
+
+  // Move focus to the card when a step opens so keyboard and screen-reader
+  // users land on the guidance. The card remounts per step (keyed by id), so
+  // this fires once per step.
+  useEffect(() => {
+    cardRef.current?.focus();
+  }, []);
 
   if (!currentStep) return null;
 
@@ -90,9 +97,12 @@ const TourCard: React.FC<TourCardProps> = ({ rect }) => {
       ref={cardRef}
       role="dialog"
       aria-label="Guided tour"
+      aria-live="polite"
+      tabIndex={-1}
       className={cn(
         "pointer-events-auto fixed z-[45] w-[340px] max-w-[calc(100vw-16px)]",
-        "rounded-lg border border-gray-700 bg-gray-900 text-gray-300 shadow-2xl"
+        "rounded-lg border border-gray-700 bg-gray-900 text-gray-300 shadow-2xl outline-none",
+        "animate-in fade-in-0 zoom-in-95 duration-200 motion-reduce:animate-none"
       )}
       style={pos}
     >

--- a/frontend/src/components/onboarding/TourCard.tsx
+++ b/frontend/src/components/onboarding/TourCard.tsx
@@ -1,0 +1,145 @@
+import React, { useLayoutEffect, useRef, useState } from "react";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useOnboarding } from "@/contexts/OnboardingContext";
+
+const MARGIN = 8;
+const GAP = 12;
+const CARD_W = 340;
+
+const clamp = (v: number, lo: number, hi: number) =>
+  Math.max(lo, Math.min(hi, v));
+
+interface TourCardProps {
+  /** Bounding rect of the highlighted element, or null for a centered card. */
+  rect: DOMRect | null;
+}
+
+const TourCard: React.FC<TourCardProps> = ({ rect }) => {
+  const { currentStep, stepIndex, totalSteps, next, back, skipStep, stop } =
+    useOnboarding();
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState({ w: CARD_W, h: 0 });
+
+  useLayoutEffect(() => {
+    if (cardRef.current) {
+      const r = cardRef.current.getBoundingClientRect();
+      setSize({ w: r.width, h: r.height });
+    }
+  }, [currentStep?.id, rect]);
+
+  if (!currentStep) return null;
+
+  const placement = currentStep.placement ?? "bottom";
+  const centered = !rect || placement === "center";
+  const isLast = stepIndex >= totalSteps - 1;
+  const isFirst = stepIndex <= 0;
+
+  let pos: React.CSSProperties;
+  if (centered) {
+    pos = { top: "50%", left: "50%", transform: "translate(-50%, -50%)" };
+  } else {
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    let top = 0;
+    let left = 0;
+    switch (placement) {
+      case "top":
+        top = rect!.top - size.h - GAP;
+        left = rect!.left + rect!.width / 2 - size.w / 2;
+        break;
+      case "left":
+        left = rect!.left - size.w - GAP;
+        top = rect!.top + rect!.height / 2 - size.h / 2;
+        break;
+      case "right":
+        left = rect!.right + GAP;
+        top = rect!.top + rect!.height / 2 - size.h / 2;
+        break;
+      case "bottom":
+      default:
+        top = rect!.bottom + GAP;
+        left = rect!.left + rect!.width / 2 - size.w / 2;
+        break;
+    }
+    // Flip to the opposite side if the preferred one overflows the viewport.
+    if (placement === "bottom" && top + size.h > vh - MARGIN)
+      top = rect!.top - size.h - GAP;
+    if (placement === "top" && top < MARGIN) top = rect!.bottom + GAP;
+    if (placement === "right" && left + size.w > vw - MARGIN)
+      left = rect!.left - size.w - GAP;
+    if (placement === "left" && left < MARGIN) left = rect!.right + GAP;
+    // Keep the card fully on screen.
+    left = clamp(left, MARGIN, vw - size.w - MARGIN);
+    top = clamp(top, MARGIN, vh - size.h - MARGIN);
+    pos = { top, left };
+  }
+
+  return (
+    <div
+      ref={cardRef}
+      role="dialog"
+      aria-label="Guided tour"
+      className={cn(
+        "pointer-events-auto fixed z-[45] w-[340px] max-w-[calc(100vw-16px)]",
+        "rounded-lg border border-gray-700 bg-gray-900 text-gray-300 shadow-2xl"
+      )}
+      style={pos}
+    >
+      <button
+        type="button"
+        onClick={() => stop(false)}
+        aria-label="Exit tour"
+        className="absolute right-2 top-2 rounded p-1 text-gray-400 hover:bg-gray-800 hover:text-white"
+      >
+        <X className="h-4 w-4" />
+      </button>
+
+      <div className="p-4 pt-5">
+        <p className="mb-1 text-xs font-medium uppercase tracking-wide text-blue-400">
+          Step {stepIndex + 1} of {totalSteps}
+        </p>
+        <h3 className="pr-6 text-base font-semibold text-white">
+          {currentStep.title}
+        </h3>
+        <p className="mt-2 text-sm leading-relaxed text-gray-300">
+          {currentStep.body}
+        </p>
+
+        <div className="mt-4 flex items-center justify-between gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={back}
+            disabled={isFirst}
+            className="text-gray-400 hover:text-white disabled:opacity-40"
+          >
+            Back
+          </Button>
+          <div className="flex items-center gap-2">
+            {currentStep.optional && !isLast && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={skipStep}
+                className="text-gray-400 hover:text-white"
+              >
+                Skip
+              </Button>
+            )}
+            <Button
+              size="sm"
+              onClick={next}
+              className="bg-blue-600 text-white hover:bg-blue-700"
+            >
+              {isLast ? "Finish" : "Next"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TourCard;

--- a/frontend/src/components/onboarding/TourLauncher.tsx
+++ b/frontend/src/components/onboarding/TourLauncher.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { HelpCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useOnboarding } from "@/contexts/OnboardingContext";
+
+interface TourLauncherProps {
+  /** "floating" pins a round button to the corner on every page; "inline" is
+   * a compact button for the landing top bar. */
+  variant?: "floating" | "inline";
+  className?: string;
+}
+
+const TourLauncher: React.FC<TourLauncherProps> = ({
+  variant = "inline",
+  className,
+}) => {
+  const { start, isActive } = useOnboarding();
+
+  // The floating button would only get in the way while the tour is running.
+  if (variant === "floating" && isActive) return null;
+
+  if (variant === "floating") {
+    return (
+      <button
+        type="button"
+        onClick={start}
+        aria-label="Start the guided tour"
+        title="Guided tour"
+        className={cn(
+          "fixed bottom-4 right-4 z-30 flex h-11 w-11 items-center justify-center",
+          "rounded-full border border-gray-700 bg-gray-900 text-gray-300 shadow-lg",
+          "transition-colors hover:bg-gray-800 hover:text-white",
+          className
+        )}
+      >
+        <HelpCircle className="h-5 w-5" />
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={start}
+      aria-label="Start the guided tour"
+      className={cn(
+        "flex items-center gap-1.5 rounded-md border border-gray-700 px-2.5 py-1.5",
+        "text-xs font-medium text-gray-300 transition-colors hover:bg-gray-800 hover:text-white",
+        className
+      )}
+    >
+      <HelpCircle className="h-4 w-4" />
+      Tour
+    </button>
+  );
+};
+
+export default TourLauncher;

--- a/frontend/src/components/onboarding/WelcomeDialog.tsx
+++ b/frontend/src/components/onboarding/WelcomeDialog.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Compass, Route } from "lucide-react";
+
+interface WelcomeDialogProps {
+  open: boolean;
+  onStart: () => void;
+  onDismiss: () => void;
+}
+
+// The stages a newcomer will walk through, shown as a quick preview so the
+// tour's value is clear before they commit two minutes to it.
+const STAGES = ["Calibrate", "Record", "Train", "Run"];
+
+const WelcomeDialog: React.FC<WelcomeDialogProps> = ({
+  open,
+  onStart,
+  onDismiss,
+}) => {
+  return (
+    <Dialog open={open} onOpenChange={(next) => (next ? undefined : onDismiss())}>
+      <DialogContent className="bg-gray-900 border-gray-700 text-gray-300 sm:max-w-lg">
+        <DialogHeader className="text-center sm:text-center">
+          <DialogTitle className="flex items-center justify-center gap-2 text-xl text-white">
+            <Compass className="h-6 w-6 text-blue-400" />
+            Welcome to LeLab
+          </DialogTitle>
+          <DialogDescription>
+            New to teaching a robot arm? A two-minute guided tour walks you
+            through the whole loop, no jargon required.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="py-2">
+          <div className="flex items-center justify-center gap-2 text-sm text-gray-400">
+            {STAGES.map((stage, i) => (
+              <React.Fragment key={stage}>
+                <span className="rounded-md bg-gray-800 px-2.5 py-1 font-medium text-gray-200">
+                  {stage}
+                </span>
+                {i < STAGES.length - 1 && (
+                  <span className="text-gray-600">→</span>
+                )}
+              </React.Fragment>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row-reverse">
+          <Button
+            onClick={onStart}
+            className="w-full bg-blue-600 text-white hover:bg-blue-700 sm:w-auto"
+          >
+            <Route className="mr-2 h-4 w-4" />
+            Take the tour
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={onDismiss}
+            className="w-full text-gray-400 hover:text-white sm:w-auto"
+          >
+            Maybe later
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default WelcomeDialog;

--- a/frontend/src/contexts/OnboardingContext.tsx
+++ b/frontend/src/contexts/OnboardingContext.tsx
@@ -10,8 +10,10 @@ import React, {
 import { useLocation, useNavigate } from "react-router-dom";
 import { ONBOARDING_STEPS, TourStep } from "@/lib/onboardingSteps";
 import { useOnboardingProgress } from "@/hooks/useOnboardingProgress";
+import { isHostedSpace } from "@/lib/isHostedSpace";
 import SpotlightOverlay from "@/components/onboarding/SpotlightOverlay";
 import TourLauncher from "@/components/onboarding/TourLauncher";
+import WelcomeDialog from "@/components/onboarding/WelcomeDialog";
 
 // Persisted across sessions, mirroring the useUpdateCheck pattern. The `-v1`
 // suffix lets a future revamp re-offer the tour to everyone by bumping it.
@@ -71,6 +73,7 @@ export const OnboardingProvider: React.FC<{ children: React.ReactNode }> = ({
   const [isActive, setIsActive] = useState(false);
   const [currentStepId, setCurrentStepId] = useState<string | null>(null);
   const [hasSeen, setHasSeen] = useState<boolean>(() => readStatus() !== null);
+  const [showWelcome, setShowWelcome] = useState(false);
 
   const progress = useOnboardingProgress(isActive);
 
@@ -103,8 +106,25 @@ export const OnboardingProvider: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   const start = useCallback(() => {
+    setShowWelcome(false);
     setCurrentStepId(ONBOARDING_STEPS[0]?.id ?? null);
     setIsActive(true);
+  }, []);
+
+  const dismissWelcome = useCallback(() => {
+    setShowWelcome(false);
+    writeStatus("dismissed");
+    setHasSeen(true);
+  }, []);
+
+  // Offer the tour once, on the first visit only. Suppressed on the hosted HF
+  // Space, where UsageInstructionsModal owns the first-run moment (a
+  // non-dismissible install prompt) — the two must never stack. The corner
+  // launcher stays available everywhere regardless.
+  useEffect(() => {
+    if (readStatus() === null && !isHostedSpace()) {
+      setShowWelcome(true);
+    }
   }, []);
 
   const next = useCallback(() => {
@@ -211,6 +231,11 @@ export const OnboardingProvider: React.FC<{ children: React.ReactNode }> = ({
   return (
     <OnboardingContext.Provider value={value}>
       {children}
+      <WelcomeDialog
+        open={showWelcome}
+        onStart={start}
+        onDismiss={dismissWelcome}
+      />
       <SpotlightOverlay />
       <TourLauncher variant="floating" />
     </OnboardingContext.Provider>

--- a/frontend/src/contexts/OnboardingContext.tsx
+++ b/frontend/src/contexts/OnboardingContext.tsx
@@ -9,12 +9,17 @@ import React, {
 } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { ONBOARDING_STEPS, TourStep } from "@/lib/onboardingSteps";
+import { useOnboardingProgress } from "@/hooks/useOnboardingProgress";
 import SpotlightOverlay from "@/components/onboarding/SpotlightOverlay";
 import TourLauncher from "@/components/onboarding/TourLauncher";
 
 // Persisted across sessions, mirroring the useUpdateCheck pattern. The `-v1`
 // suffix lets a future revamp re-offer the tour to everyone by bumping it.
 const STORAGE_KEY = "lelab:onboarding-v1";
+// Delay before auto-advancing once a step's goal is met, so the user sees the
+// "done" state register before moving on.
+const AUTO_ADVANCE_MS = 1100;
+
 type OnboardingStatus = "dismissed" | "completed";
 
 const readStatus = (): OnboardingStatus | null => {
@@ -37,8 +42,13 @@ const writeStatus = (status: OnboardingStatus) => {
 interface OnboardingContextValue {
   isActive: boolean;
   currentStep: TourStep | null;
+  /** 0-based index of the current step among the steps visible to this user. */
   stepIndex: number;
   totalSteps: number;
+  /** True when the current step's goal has been achieved. */
+  currentComplete: boolean;
+  /** True when the current step's prerequisite is not met yet (info only). */
+  currentGated: boolean;
   /** True once the user has finished or dismissed the tour at least once. */
   hasSeen: boolean;
   start: () => void;
@@ -59,39 +69,58 @@ export const OnboardingProvider: React.FC<{ children: React.ReactNode }> = ({
   const location = useLocation();
 
   const [isActive, setIsActive] = useState(false);
-  const [stepIndex, setStepIndex] = useState(0);
+  const [currentStepId, setCurrentStepId] = useState<string | null>(null);
   const [hasSeen, setHasSeen] = useState<boolean>(() => readStatus() !== null);
 
-  const totalSteps = ONBOARDING_STEPS.length;
+  const progress = useOnboardingProgress(isActive);
+
+  // Steps whose `show` predicate excludes this user drop out — but the current
+  // step is always kept so it can never vanish mid-view and strand the tour.
+  const visibleSteps = useMemo(
+    () =>
+      ONBOARDING_STEPS.filter(
+        (s) => s.id === currentStepId || !s.show || s.show(progress)
+      ),
+    [progress, currentStepId]
+  );
+
+  const stepIndex = currentStepId
+    ? visibleSteps.findIndex((s) => s.id === currentStepId)
+    : -1;
   const currentStep =
-    isActive && stepIndex >= 0 && stepIndex < totalSteps
-      ? ONBOARDING_STEPS[stepIndex]
-      : null;
+    isActive && stepIndex >= 0 ? visibleSteps[stepIndex] : null;
+
+  const currentComplete = currentStep?.isComplete
+    ? currentStep.isComplete(progress)
+    : false;
+  const currentGated = currentStep?.gate ? !currentStep.gate(progress) : false;
 
   const stop = useCallback((completed: boolean) => {
     setIsActive(false);
+    setCurrentStepId(null);
     writeStatus(completed ? "completed" : "dismissed");
     setHasSeen(true);
   }, []);
 
   const start = useCallback(() => {
-    setStepIndex(0);
+    setCurrentStepId(ONBOARDING_STEPS[0]?.id ?? null);
     setIsActive(true);
   }, []);
 
   const next = useCallback(() => {
-    setStepIndex((i) => {
-      if (i >= totalSteps - 1) {
-        stop(true);
-        return i;
-      }
-      return i + 1;
-    });
-  }, [totalSteps, stop]);
+    const idx = visibleSteps.findIndex((s) => s.id === currentStepId);
+    if (idx < 0) return;
+    if (idx >= visibleSteps.length - 1) {
+      stop(true);
+      return;
+    }
+    setCurrentStepId(visibleSteps[idx + 1].id);
+  }, [visibleSteps, currentStepId, stop]);
 
   const back = useCallback(() => {
-    setStepIndex((i) => Math.max(0, i - 1));
-  }, []);
+    const idx = visibleSteps.findIndex((s) => s.id === currentStepId);
+    if (idx > 0) setCurrentStepId(visibleSteps[idx - 1].id);
+  }, [visibleSteps, currentStepId]);
 
   const skipStep = next;
 
@@ -126,12 +155,36 @@ export const OnboardingProvider: React.FC<{ children: React.ReactNode }> = ({
     navigate(currentStep.route);
   }, [isActive, currentStep, location.pathname, navigate]);
 
+  // Auto-advance when a step's goal is met — but only on a false->true
+  // transition while the step is shown, so returning to an already-complete
+  // step via Back doesn't immediately bounce forward again.
+  const autoRef = useRef<{ id: string | null; done: boolean }>({
+    id: null,
+    done: false,
+  });
+  useEffect(() => {
+    if (!isActive || !currentStep) return;
+    if (autoRef.current.id !== currentStep.id) {
+      // Entering a (possibly already-complete) step: set the baseline and
+      // never auto-advance out of a step that was already done on arrival.
+      autoRef.current = { id: currentStep.id, done: currentComplete };
+      return;
+    }
+    if (!autoRef.current.done && currentComplete) {
+      autoRef.current.done = true;
+      const t = setTimeout(() => next(), AUTO_ADVANCE_MS);
+      return () => clearTimeout(t);
+    }
+  }, [isActive, currentStep, currentComplete, next]);
+
   const value = useMemo<OnboardingContextValue>(
     () => ({
       isActive,
       currentStep,
       stepIndex,
-      totalSteps,
+      totalSteps: visibleSteps.length,
+      currentComplete,
+      currentGated,
       hasSeen,
       start,
       next,
@@ -143,7 +196,9 @@ export const OnboardingProvider: React.FC<{ children: React.ReactNode }> = ({
       isActive,
       currentStep,
       stepIndex,
-      totalSteps,
+      visibleSteps.length,
+      currentComplete,
+      currentGated,
       hasSeen,
       start,
       next,

--- a/frontend/src/contexts/OnboardingContext.tsx
+++ b/frontend/src/contexts/OnboardingContext.tsx
@@ -1,0 +1,134 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+import { ONBOARDING_STEPS, TourStep } from "@/lib/onboardingSteps";
+import SpotlightOverlay from "@/components/onboarding/SpotlightOverlay";
+import TourLauncher from "@/components/onboarding/TourLauncher";
+
+// Persisted across sessions, mirroring the useUpdateCheck pattern. The `-v1`
+// suffix lets a future revamp re-offer the tour to everyone by bumping it.
+const STORAGE_KEY = "lelab:onboarding-v1";
+type OnboardingStatus = "dismissed" | "completed";
+
+const readStatus = (): OnboardingStatus | null => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw === "dismissed" || raw === "completed" ? raw : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeStatus = (status: OnboardingStatus) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, status);
+  } catch {
+    // Storage may be unavailable (private mode, quota); nothing to persist.
+  }
+};
+
+interface OnboardingContextValue {
+  isActive: boolean;
+  currentStep: TourStep | null;
+  stepIndex: number;
+  totalSteps: number;
+  /** True once the user has finished or dismissed the tour at least once. */
+  hasSeen: boolean;
+  start: () => void;
+  next: () => void;
+  back: () => void;
+  /** Advance past an optional step without performing its action. */
+  skipStep: () => void;
+  /** Leave the tour. `completed` records how it ended for the persisted flag. */
+  stop: (completed: boolean) => void;
+}
+
+const OnboardingContext = createContext<OnboardingContextValue | null>(null);
+
+export const OnboardingProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [isActive, setIsActive] = useState(false);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [hasSeen, setHasSeen] = useState<boolean>(() => readStatus() !== null);
+
+  const totalSteps = ONBOARDING_STEPS.length;
+  const currentStep =
+    isActive && stepIndex >= 0 && stepIndex < totalSteps
+      ? ONBOARDING_STEPS[stepIndex]
+      : null;
+
+  const stop = useCallback((completed: boolean) => {
+    setIsActive(false);
+    writeStatus(completed ? "completed" : "dismissed");
+    setHasSeen(true);
+  }, []);
+
+  const start = useCallback(() => {
+    setStepIndex(0);
+    setIsActive(true);
+  }, []);
+
+  const next = useCallback(() => {
+    setStepIndex((i) => {
+      if (i >= totalSteps - 1) {
+        stop(true);
+        return i;
+      }
+      return i + 1;
+    });
+  }, [totalSteps, stop]);
+
+  const back = useCallback(() => {
+    setStepIndex((i) => Math.max(0, i - 1));
+  }, []);
+
+  const skipStep = next;
+
+  const value = useMemo<OnboardingContextValue>(
+    () => ({
+      isActive,
+      currentStep,
+      stepIndex,
+      totalSteps,
+      hasSeen,
+      start,
+      next,
+      back,
+      skipStep,
+      stop,
+    }),
+    [
+      isActive,
+      currentStep,
+      stepIndex,
+      totalSteps,
+      hasSeen,
+      start,
+      next,
+      back,
+      skipStep,
+      stop,
+    ]
+  );
+
+  return (
+    <OnboardingContext.Provider value={value}>
+      {children}
+      <SpotlightOverlay />
+      <TourLauncher variant="floating" />
+    </OnboardingContext.Provider>
+  );
+};
+
+export const useOnboarding = (): OnboardingContextValue => {
+  const ctx = useContext(OnboardingContext);
+  if (!ctx) {
+    throw new Error("useOnboarding must be used within an OnboardingProvider");
+  }
+  return ctx;
+};

--- a/frontend/src/contexts/OnboardingContext.tsx
+++ b/frontend/src/contexts/OnboardingContext.tsx
@@ -2,9 +2,12 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { ONBOARDING_STEPS, TourStep } from "@/lib/onboardingSteps";
 import SpotlightOverlay from "@/components/onboarding/SpotlightOverlay";
 import TourLauncher from "@/components/onboarding/TourLauncher";
@@ -52,6 +55,9 @@ const OnboardingContext = createContext<OnboardingContextValue | null>(null);
 export const OnboardingProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
   const [isActive, setIsActive] = useState(false);
   const [stepIndex, setStepIndex] = useState(0);
   const [hasSeen, setHasSeen] = useState<boolean>(() => readStatus() !== null);
@@ -88,6 +94,37 @@ export const OnboardingProvider: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   const skipStep = next;
+
+  // Navigate to a step's route once, when that step is entered — never during
+  // render. We deliberately do NOT re-navigate on later location changes, so a
+  // user who clicks away mid-step isn't yanked back (the spotlight just falls
+  // back to a centered card). The calibration page needs a robot_name in
+  // navigation state to show the right robot's controls, so we forward the
+  // currently-selected robot (persisted by useRobots).
+  const lastNavStepId = useRef<string | null>(null);
+  useEffect(() => {
+    if (!isActive || !currentStep) {
+      lastNavStepId.current = null;
+      return;
+    }
+    if (lastNavStepId.current === currentStep.id) return;
+    lastNavStepId.current = currentStep.id;
+    if (location.pathname === currentStep.route) return;
+    if (currentStep.route === "/calibration") {
+      let robotName: string | null = null;
+      try {
+        robotName = localStorage.getItem("lelab.selectedRobot");
+      } catch {
+        // Storage unavailable — fall through to a plain navigation.
+      }
+      navigate(
+        "/calibration",
+        robotName ? { state: { robot_name: robotName } } : undefined
+      );
+      return;
+    }
+    navigate(currentStep.route);
+  }, [isActive, currentStep, location.pathname, navigate]);
 
   const value = useMemo<OnboardingContextValue>(
     () => ({

--- a/frontend/src/hooks/useOnboardingProgress.ts
+++ b/frontend/src/hooks/useOnboardingProgress.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useApi } from "@/contexts/ApiContext";
+import { useHfAuth } from "@/contexts/HfAuthContext";
+import { listDatasets } from "@/lib/replayApi";
+import { listHubJobs, listJobs } from "@/lib/jobsApi";
+import type { RobotRecord } from "@/hooks/useRobots";
+import type { ProgressSnapshot } from "@/lib/onboardingSteps";
+
+// Matches the key useRobots persists the selected robot under.
+const SELECTED_KEY = "lelab.selectedRobot";
+const POLL_MS = 2000;
+
+const EMPTY: ProgressSnapshot = {
+  hasSelectedRobot: false,
+  robotIsClean: false,
+  hasLocalDataset: false,
+  hasTrainedModel: false,
+  isAuthenticated: false,
+};
+
+/**
+ * A read-only snapshot of how far the user has actually gotten, derived from
+ * existing endpoints. It only fetches while the tour is active, so it adds
+ * zero cost when the tour is closed. Deliberately does NOT reuse useRobots
+ * (which refetches per route and owns selection) — a second instance would
+ * double traffic and race the selection state.
+ */
+export function useOnboardingProgress(active: boolean): ProgressSnapshot {
+  const { baseUrl, fetchWithHeaders } = useApi();
+  const { auth } = useHfAuth();
+  const [snapshot, setSnapshot] = useState<ProgressSnapshot>(EMPTY);
+  const authStatus = auth.status;
+
+  const refresh = useCallback(async () => {
+    let selectedName: string | null = null;
+    try {
+      selectedName = localStorage.getItem(SELECTED_KEY);
+    } catch {
+      // Storage unavailable — treat as no selection.
+    }
+
+    const [robotsBody, datasets, jobs, hub] = await Promise.all([
+      fetchWithHeaders(`${baseUrl}/robots`)
+        .then((r) => (r.ok ? r.json() : null))
+        .catch(() => null),
+      listDatasets(baseUrl, fetchWithHeaders).catch(() => []),
+      listJobs(baseUrl, fetchWithHeaders, 20).catch(() => []),
+      listHubJobs(baseUrl, fetchWithHeaders).catch(() => ({
+        authenticated: false,
+        jobs: [],
+        models: [],
+      })),
+    ]);
+
+    const records: RobotRecord[] = robotsBody?.robots ?? [];
+    const selected = selectedName
+      ? records.find((r) => r.name === selectedName) ?? null
+      : null;
+
+    setSnapshot({
+      hasSelectedRobot: !!selected,
+      robotIsClean: !!selected?.is_clean,
+      hasLocalDataset: datasets.some(
+        (d) => d.source === "local" || d.source === "both"
+      ),
+      hasTrainedModel:
+        jobs.some((j) => j.checkpoint_count > 0 || j.state === "done") ||
+        hub.models.length > 0,
+      isAuthenticated: authStatus === "authenticated" || hub.authenticated,
+    });
+  }, [baseUrl, fetchWithHeaders, authStatus]);
+
+  // Keep the latest refresh in a ref so the polling interval never tears down.
+  const refreshRef = useRef(refresh);
+  refreshRef.current = refresh;
+
+  useEffect(() => {
+    if (!active) {
+      setSnapshot(EMPTY);
+      return;
+    }
+    let cancelled = false;
+    const tick = () => {
+      if (!cancelled) refreshRef.current();
+    };
+    tick();
+    const id = setInterval(tick, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [active]);
+
+  return snapshot;
+}

--- a/frontend/src/hooks/useOnboardingProgress.ts
+++ b/frontend/src/hooks/useOnboardingProgress.ts
@@ -2,13 +2,16 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useApi } from "@/contexts/ApiContext";
 import { useHfAuth } from "@/contexts/HfAuthContext";
 import { listDatasets } from "@/lib/replayApi";
-import { listHubJobs, listJobs } from "@/lib/jobsApi";
+import { listJobs } from "@/lib/jobsApi";
 import type { RobotRecord } from "@/hooks/useRobots";
 import type { ProgressSnapshot } from "@/lib/onboardingSteps";
 
 // Matches the key useRobots persists the selected robot under.
 const SELECTED_KEY = "lelab.selectedRobot";
-const POLL_MS = 2000;
+// The tour only needs to notice progress within a few seconds; a gentle cadence
+// keeps load off the backend, and polling pauses entirely while the tab is
+// hidden.
+const POLL_MS = 3000;
 
 const EMPTY: ProgressSnapshot = {
   hasSelectedRobot: false,
@@ -24,12 +27,16 @@ const EMPTY: ProgressSnapshot = {
  * zero cost when the tour is closed. Deliberately does NOT reuse useRobots
  * (which refetches per route and owns selection) — a second instance would
  * double traffic and race the selection state.
+ *
+ * Only cheap local endpoints are polled: no /jobs/hub, so the tour never adds
+ * Hugging Face Hub API load. Tracked cloud jobs already surface in /jobs, and
+ * auth comes from the existing HfAuth context.
  */
 export function useOnboardingProgress(active: boolean): ProgressSnapshot {
   const { baseUrl, fetchWithHeaders } = useApi();
   const { auth } = useHfAuth();
   const [snapshot, setSnapshot] = useState<ProgressSnapshot>(EMPTY);
-  const authStatus = auth.status;
+  const isAuthenticated = auth.status === "authenticated";
 
   const refresh = useCallback(async () => {
     let selectedName: string | null = null;
@@ -39,17 +46,12 @@ export function useOnboardingProgress(active: boolean): ProgressSnapshot {
       // Storage unavailable — treat as no selection.
     }
 
-    const [robotsBody, datasets, jobs, hub] = await Promise.all([
+    const [robotsBody, datasets, jobs] = await Promise.all([
       fetchWithHeaders(`${baseUrl}/robots`)
         .then((r) => (r.ok ? r.json() : null))
         .catch(() => null),
       listDatasets(baseUrl, fetchWithHeaders).catch(() => []),
       listJobs(baseUrl, fetchWithHeaders, 20).catch(() => []),
-      listHubJobs(baseUrl, fetchWithHeaders).catch(() => ({
-        authenticated: false,
-        jobs: [],
-        models: [],
-      })),
     ]);
 
     const records: RobotRecord[] = robotsBody?.robots ?? [];
@@ -63,12 +65,12 @@ export function useOnboardingProgress(active: boolean): ProgressSnapshot {
       hasLocalDataset: datasets.some(
         (d) => d.source === "local" || d.source === "both"
       ),
-      hasTrainedModel:
-        jobs.some((j) => j.checkpoint_count > 0 || j.state === "done") ||
-        hub.models.length > 0,
-      isAuthenticated: authStatus === "authenticated" || hub.authenticated,
+      hasTrainedModel: jobs.some(
+        (j) => j.checkpoint_count > 0 || j.state === "done"
+      ),
+      isAuthenticated,
     });
-  }, [baseUrl, fetchWithHeaders, authStatus]);
+  }, [baseUrl, fetchWithHeaders, isAuthenticated]);
 
   // Keep the latest refresh in a ref so the polling interval never tears down.
   const refreshRef = useRef(refresh);
@@ -80,14 +82,28 @@ export function useOnboardingProgress(active: boolean): ProgressSnapshot {
       return;
     }
     let cancelled = false;
-    const tick = () => {
-      if (!cancelled) refreshRef.current();
+    let inFlight = false;
+    const tick = async () => {
+      // Skip while backgrounded, and never let ticks pile up if one is slow.
+      if (cancelled || inFlight || document.visibilityState === "hidden") return;
+      inFlight = true;
+      try {
+        await refreshRef.current();
+      } finally {
+        inFlight = false;
+      }
     };
     tick();
     const id = setInterval(tick, POLL_MS);
+    // Refresh promptly when the user returns to the tab.
+    const onVisible = () => {
+      if (document.visibilityState === "visible") tick();
+    };
+    document.addEventListener("visibilitychange", onVisible);
     return () => {
       cancelled = true;
       clearInterval(id);
+      document.removeEventListener("visibilitychange", onVisible);
     };
   }, [active]);
 

--- a/frontend/src/hooks/useOnboardingProgress.ts
+++ b/frontend/src/hooks/useOnboardingProgress.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useApi } from "@/contexts/ApiContext";
 import { useHfAuth } from "@/contexts/HfAuthContext";
-import { listDatasets } from "@/lib/replayApi";
+import { listLocalDatasets } from "@/lib/replayApi";
 import { listJobs } from "@/lib/jobsApi";
 import type { RobotRecord } from "@/hooks/useRobots";
 import type { ProgressSnapshot } from "@/lib/onboardingSteps";
@@ -28,9 +28,10 @@ const EMPTY: ProgressSnapshot = {
  * (which refetches per route and owns selection) — a second instance would
  * double traffic and race the selection state.
  *
- * Only cheap local endpoints are polled: no /jobs/hub, so the tour never adds
- * Hugging Face Hub API load. Tracked cloud jobs already surface in /jobs, and
- * auth comes from the existing HfAuth context.
+ * Only cheap local endpoints are polled — /robots, /datasets?scope=local (a
+ * filesystem scan, no Hub call), and /jobs — so the tour never adds Hugging
+ * Face Hub API load. Tracked cloud jobs already surface in /jobs, and auth
+ * comes from the existing HfAuth context.
  */
 export function useOnboardingProgress(active: boolean): ProgressSnapshot {
   const { baseUrl, fetchWithHeaders } = useApi();
@@ -50,7 +51,7 @@ export function useOnboardingProgress(active: boolean): ProgressSnapshot {
       fetchWithHeaders(`${baseUrl}/robots`)
         .then((r) => (r.ok ? r.json() : null))
         .catch(() => null),
-      listDatasets(baseUrl, fetchWithHeaders).catch(() => []),
+      listLocalDatasets(baseUrl, fetchWithHeaders).catch(() => []),
       listJobs(baseUrl, fetchWithHeaders, 20).catch(() => []),
     ]);
 

--- a/frontend/src/lib/onboardingSteps.ts
+++ b/frontend/src/lib/onboardingSteps.ts
@@ -1,8 +1,22 @@
 // Declarative model for the beginner onboarding tour. Each step points the
 // spotlight at a real element (by its `data-tour` attribute) on a given route
 // and explains, in plain language, one stage of the record -> train -> run loop.
+//
+// `gate` / `isComplete` read a live snapshot of how far the user has actually
+// gotten (see useOnboardingProgress) so the tour can adapt and auto-advance.
+// Both are optional: a step without them is a simple click-through.
 
 export type Placement = "top" | "bottom" | "left" | "right" | "center";
+
+// A read-only snapshot of the user's real progress, derived entirely from
+// existing endpoints (/robots, /datasets, /jobs, /hf-auth-status).
+export interface ProgressSnapshot {
+  hasSelectedRobot: boolean;
+  robotIsClean: boolean;
+  hasLocalDataset: boolean;
+  hasTrainedModel: boolean;
+  isAuthenticated: boolean;
+}
 
 export interface TourStep {
   /** Stable id, also used as the log/debug label. */
@@ -16,6 +30,12 @@ export interface TourStep {
   placement?: Placement;
   /** Optional steps can be skipped without doing the action (e.g. no hardware). */
   optional?: boolean;
+  /** When false, the step's action isn't possible yet (informational only). */
+  gate?: (s: ProgressSnapshot) => boolean;
+  /** When true, the user has done this step's action; enables auto-advance. */
+  isComplete?: (s: ProgressSnapshot) => boolean;
+  /** When present and false, the step is skipped entirely for this user. */
+  show?: (s: ProgressSnapshot) => boolean;
 }
 
 export const ONBOARDING_STEPS: TourStep[] = [
@@ -33,6 +53,7 @@ export const ONBOARDING_STEPS: TourStep[] = [
     placement: "bottom",
     title: "Pick or name your arm",
     body: "Start here. Choose an existing robot, or type a new name to create one. Everything else in the tour hangs off the arm you select.",
+    isComplete: (s) => s.hasSelectedRobot,
   },
   {
     id: "calibrate",
@@ -42,6 +63,7 @@ export const ONBOARDING_STEPS: TourStep[] = [
     title: "Calibrate the arms",
     body: "Calibration teaches the app each joint's range of motion so movements map correctly. Run it once for the leader arm, then the follower. Press Start and follow the on-screen steps.",
     optional: true,
+    isComplete: (s) => s.robotIsClean,
   },
   {
     id: "cameras",
@@ -60,6 +82,7 @@ export const ONBOARDING_STEPS: TourStep[] = [
     title: "Try teleoperation (optional)",
     body: "Drive the follower arm by moving the leader. It's a good way to confirm calibration feels right before you record anything. This button unlocks once the arm is calibrated.",
     optional: true,
+    gate: (s) => s.robotIsClean,
   },
   {
     id: "record",
@@ -68,6 +91,8 @@ export const ONBOARDING_STEPS: TourStep[] = [
     placement: "bottom",
     title: "Record a dataset",
     body: "A dataset is a set of episodes: one attempt at your task each. Episode time is how long each attempt runs; reset time is the pause to reposition objects between attempts. Aim for 10 to 50 clean episodes to start.",
+    gate: (s) => s.robotIsClean,
+    isComplete: (s) => s.hasLocalDataset,
   },
   {
     id: "train",
@@ -76,6 +101,8 @@ export const ONBOARDING_STEPS: TourStep[] = [
     placement: "bottom",
     title: "Train a policy",
     body: "Turn your recorded episodes into a policy the robot can run. ACT is fast and a great first choice; SmolVLA is a larger vision-language model. You can train on your own GPU, or rent one in the cloud with a Hugging Face login.",
+    gate: (s) => s.hasLocalDataset,
+    isComplete: (s) => s.hasTrainedModel,
   },
   {
     id: "watch-training",
@@ -102,6 +129,7 @@ export const ONBOARDING_STEPS: TourStep[] = [
     title: "Share on the Hub (optional)",
     body: "Log in to Hugging Face to push your datasets and trained models to the Hub, so you can back them up, share them, or train in the cloud.",
     optional: true,
+    show: (s) => !s.isAuthenticated,
   },
   {
     id: "done",

--- a/frontend/src/lib/onboardingSteps.ts
+++ b/frontend/src/lib/onboardingSteps.ts
@@ -1,0 +1,113 @@
+// Declarative model for the beginner onboarding tour. Each step points the
+// spotlight at a real element (by its `data-tour` attribute) on a given route
+// and explains, in plain language, one stage of the record -> train -> run loop.
+
+export type Placement = "top" | "bottom" | "left" | "right" | "center";
+
+export interface TourStep {
+  /** Stable id, also used as the log/debug label. */
+  id: string;
+  /** Route this step lives on; the tour navigates here before showing it. */
+  route: string;
+  /** `data-tour` value of the element to spotlight. Omit for a centered card. */
+  target?: string;
+  title: string;
+  body: string;
+  placement?: Placement;
+  /** Optional steps can be skipped without doing the action (e.g. no hardware). */
+  optional?: boolean;
+}
+
+export const ONBOARDING_STEPS: TourStep[] = [
+  {
+    id: "welcome",
+    route: "/",
+    placement: "center",
+    title: "Welcome to LeLab",
+    body: "This quick tour walks you from a fresh setup to a robot that runs a policy you trained yourself: calibrate, record, train, run. It takes about two minutes, and you can leave anytime with Esc.",
+  },
+  {
+    id: "pick-robot",
+    route: "/",
+    target: "robot-selector",
+    placement: "bottom",
+    title: "Pick or name your arm",
+    body: "Start here. Choose an existing robot, or type a new name to create one. Everything else in the tour hangs off the arm you select.",
+  },
+  {
+    id: "calibrate",
+    route: "/calibration",
+    target: "calibration-start",
+    placement: "bottom",
+    title: "Calibrate the arms",
+    body: "Calibration teaches the app each joint's range of motion so movements map correctly. Run it once for the leader arm, then the follower. Press Start and follow the on-screen steps.",
+    optional: true,
+  },
+  {
+    id: "cameras",
+    route: "/calibration",
+    target: "calibration-cameras",
+    placement: "top",
+    title: "Add cameras (if your task needs sight)",
+    body: "If the robot has to see what it's doing, add one or more cameras here. They're saved with this robot and reused when you record. Skip this if your task doesn't need vision.",
+    optional: true,
+  },
+  {
+    id: "teleop",
+    route: "/",
+    target: "robot-teleop",
+    placement: "top",
+    title: "Try teleoperation (optional)",
+    body: "Drive the follower arm by moving the leader. It's a good way to confirm calibration feels right before you record anything. This button unlocks once the arm is calibrated.",
+    optional: true,
+  },
+  {
+    id: "record",
+    route: "/",
+    target: "dataset-picker",
+    placement: "bottom",
+    title: "Record a dataset",
+    body: "A dataset is a set of episodes: one attempt at your task each. Episode time is how long each attempt runs; reset time is the pause to reposition objects between attempts. Aim for 10 to 50 clean episodes to start.",
+  },
+  {
+    id: "train",
+    route: "/",
+    target: "training-entry",
+    placement: "bottom",
+    title: "Train a policy",
+    body: "Turn your recorded episodes into a policy the robot can run. ACT is fast and a great first choice; SmolVLA is a larger vision-language model. You can train on your own GPU, or rent one in the cloud with a Hugging Face login.",
+  },
+  {
+    id: "watch-training",
+    route: "/",
+    target: "jobs-section",
+    placement: "top",
+    title: "Watch it train",
+    body: "Your training job shows up here with live progress. Once it has a usable checkpoint, a green play button appears on the model so you can run it.",
+  },
+  {
+    id: "inference",
+    route: "/",
+    target: "jobs-section",
+    placement: "top",
+    title: "Run your policy",
+    body: "Press the play button on a finished model to let the robot attempt the task on its own, using what it learned from your episodes. This is the payoff of the whole loop.",
+    optional: true,
+  },
+  {
+    id: "upload",
+    route: "/",
+    target: "training-entry",
+    placement: "bottom",
+    title: "Share on the Hub (optional)",
+    body: "Log in to Hugging Face to push your datasets and trained models to the Hub, so you can back them up, share them, or train in the cloud.",
+    optional: true,
+  },
+  {
+    id: "done",
+    route: "/",
+    placement: "center",
+    title: "That's the whole loop",
+    body: "Calibrate, record, train, run. You can reopen this tour anytime from the ? button in the corner. Happy building.",
+  },
+];

--- a/frontend/src/lib/replayApi.ts
+++ b/frontend/src/lib/replayApi.ts
@@ -19,3 +19,19 @@ export async function listDatasets(
     action: "List datasets",
   });
 }
+
+/**
+ * Local-cache datasets only — a pure filesystem scan on the backend, with no
+ * Hugging Face Hub call. For lightweight callers (e.g. the onboarding poll)
+ * that only need to know what exists on disk.
+ */
+export async function listLocalDatasets(
+  baseUrl: string,
+  fetcher: Fetcher,
+  signal?: AbortSignal,
+): Promise<DatasetItem[]> {
+  return apiRequest<DatasetItem[]>(baseUrl, fetcher, "/datasets?scope=local", {
+    signal,
+    action: "List local datasets",
+  });
+}

--- a/frontend/src/pages/Calibration.tsx
+++ b/frontend/src/pages/Calibration.tsx
@@ -623,6 +623,7 @@ const Calibration = () => {
                     onClick={handleStartCalibration}
                     className="w-full bg-blue-600 hover:bg-blue-700 text-white rounded-full py-6 text-lg"
                     disabled={!robotName || !deviceType || !port}
+                    data-tour="calibration-start"
                   >
                     <Play className="w-5 h-5 mr-2" />
                     Start Calibration
@@ -904,7 +905,10 @@ const Calibration = () => {
         </div>
 
         {robotName && (
-          <Card className="bg-slate-800/60 border-slate-700 backdrop-blur-sm mt-6">
+          <Card
+            className="bg-slate-800/60 border-slate-700 backdrop-blur-sm mt-6"
+            data-tour="calibration-cameras"
+          >
             <CardHeader className="flex-row items-center justify-between space-y-0">
               <CardTitle className="flex items-center gap-2 text-slate-200">
                 <Settings className="w-5 h-5 text-blue-400" />

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -241,7 +241,10 @@ const Landing = () => {
             deleteRobot={deleteRobot}
           />
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <div className="bg-gray-800 rounded-lg border border-gray-700 p-3 flex flex-col gap-2">
+            <div
+              className="bg-gray-800 rounded-lg border border-gray-700 p-3 flex flex-col gap-2"
+              data-tour="dataset-picker"
+            >
               <h3 className="font-semibold text-lg text-left h-10 flex items-center">
                 Dataset
               </h3>
@@ -266,7 +269,10 @@ const Landing = () => {
                 </Button>
               </DatasetPicker>
             </div>
-            <div className="bg-gray-800 rounded-lg border border-gray-700 p-3 flex flex-col gap-2">
+            <div
+              className="bg-gray-800 rounded-lg border border-gray-700 p-3 flex flex-col gap-2"
+              data-tour="training-entry"
+            >
               <h3 className="font-semibold text-lg text-left h-10 flex items-center">
                 Create a model
               </h3>

--- a/lelab/datasets.py
+++ b/lelab/datasets.py
@@ -133,6 +133,16 @@ def list_user_datasets() -> list[dict[str, Any]]:
     return out
 
 
+def list_local_datasets_with_source() -> list[dict[str, Any]]:
+    """Local-cache datasets tagged with source="local" — a pure filesystem scan.
+
+    Same entry shape as `list_all_datasets`, but never contacts the Hub. For
+    lightweight callers that only need to know what exists on disk (e.g. a
+    poller) and must not add Hub API load.
+    """
+    return [{**d, "source": "local"} for d in list_local_datasets()]
+
+
 def list_all_datasets() -> list[dict[str, Any]]:
     """Merged listing: Hub datasets + local cache, with `source` field.
 

--- a/lelab/server.py
+++ b/lelab/server.py
@@ -378,11 +378,15 @@ def hf_auth_login(body: HfLoginBody):
 
 
 @app.get("/datasets")
-def datasets_list():
+def datasets_list(scope: str = "all"):
     """List datasets available to the user — Hub-owned + local cache.
 
-    Each entry carries a `source` field: "local", "hub", or "both".
+    Each entry carries a `source` field: "local", "hub", or "both". Pass
+    `scope=local` for a local-only listing (a pure filesystem scan, no Hub
+    call) — for lightweight pollers that only need what exists on disk.
     """
+    if scope == "local":
+        return dataset_browser.list_local_datasets_with_source()
     return dataset_browser.list_all_datasets()
 
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -86,6 +86,22 @@ def test_list_user_datasets_returns_empty_when_not_logged_in(
         assert list_user_datasets() == []
 
 
+def test_list_local_datasets_with_source_tags_local_without_hub(
+    tmp_lerobot_home: Path,
+) -> None:
+    from lelab.datasets import list_local_datasets_with_source
+
+    _make_dataset(tmp_lerobot_home, "pusht")
+
+    # The local-only listing must never consult the Hub.
+    with patch("lelab.datasets.list_user_datasets") as hub:
+        result = list_local_datasets_with_source()
+        hub.assert_not_called()
+
+    by_id = {d["repo_id"]: d for d in result}
+    assert by_id["pusht"]["source"] == "local"
+
+
 def test_list_all_datasets_merges_hub_and_local(
     tmp_lerobot_home: Path,
 ) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -248,3 +248,32 @@ def test_import_model_route_maps_value_error_to_400(client, monkeypatch) -> None
     resp = client.post("/jobs/import", json={"source": "/tmp/x"})
     assert resp.status_code == 400
     assert "No usable model" in resp.json()["detail"]
+
+
+def test_datasets_local_scope_skips_hub_merge(client, monkeypatch) -> None:
+    """`?scope=local` returns the local-only listing and never runs the
+    Hub-merging path (which would issue a Hugging Face API call)."""
+    from lelab import datasets as datasets_mod
+
+    local = [{"repo_id": "pusht", "last_modified": None, "private": False, "source": "local"}]
+
+    def boom() -> list:
+        raise AssertionError("list_all_datasets must not run for scope=local")
+
+    monkeypatch.setattr(datasets_mod, "list_local_datasets_with_source", lambda: local)
+    monkeypatch.setattr(datasets_mod, "list_all_datasets", boom)
+
+    resp = client.get("/datasets?scope=local")
+    assert resp.status_code == 200
+    assert resp.json() == local
+
+
+def test_datasets_default_scope_uses_merged_listing(client, monkeypatch) -> None:
+    from lelab import datasets as datasets_mod
+
+    merged = [{"repo_id": "x", "last_modified": None, "private": False, "source": "both"}]
+    monkeypatch.setattr(datasets_mod, "list_all_datasets", lambda: merged)
+
+    resp = client.get("/datasets")
+    assert resp.status_code == 200
+    assert resp.json() == merged


### PR DESCRIPTION
## What this adds

A guided, interactive onboarding tour that walks a first-time user through the whole LeRobot loop
inside LeLab. From picking a robot, calibrating it, recording a dataset, training a policy to running it.
All in plain language, without them having to know the jargon or hunt for where each step lives.

Following up on our conversation about lowering the barrier for newcomers (students, hackathon
first-timers, anyone unboxing an SO-101), this is the first, self-contained piece: a real product
tour of the existing UI. It's built so a chat-style "collection assistant" can grow out of it later,
but that is deliberately out of scope here so this PR stays focused and reviewable.

## Demo

https://github.com/user-attachments/assets/8fecc9da-3ba5-4f5a-b453-d04772b752b9

## What the user sees

- On the first visit, a small "Welcome to LeLab" dialog offers a ~2-minute tour (or a quiet
  dismissal). The choice is remembered, so it never nags on return.
- Taking the tour, a spotlight dims the page and highlights the real control for each step;
  the robot selector, the calibrate button, the dataset card, the training button, the jobs list etc.
  with a short, jargon-free explanation beside it. The highlighted control stays clickable.
- The tour follows the user's real progress: it reads whether a robot is selected, calibrated,
  a dataset has been recorded, and a model trained, then marks steps done and gently moves on. Steps
  that need hardware are optional and always skippable, so someone browsing without an arm connected
  can still complete the whole tour.
- It can be replayed anytime from a `?` launcher in the landing top bar and a floating button on
  every page.

## How it works

- **No new dependencies.** The spotlight, cards, and dialog are hand-rolled on the Radix/shadcn
  primitives already in the tree.
- **Almost entirely frontend.** `frontend/dist` is left untouched (it is rebuilt from source by
  `build_frontend.yml` on merge). The only backend change is a small, additive `scope=local` mode on
  the existing `/datasets` endpoint (a pure filesystem scan, no Hub call), with test coverage — see
  below.
- **State-awareness stays off the Hub.** Progress is derived from endpoints the app already exposes,
  and the tour polls only cheap local ones while it's open (zero cost when closed): `/robots`
  (`is_clean`), `/datasets?scope=local`, and `/jobs`. It deliberately avoids `/jobs/hub` and the
  Hub-merging default of `/datasets`; tracked cloud jobs already surface in `/jobs`, and auth comes
  from the existing HfAuth context. The poll pauses while the tab is hidden.
- **Coexists with the Space.** The first-visit welcome is suppressed on the hosted HF Space, where the
  install modal already owns the first-run moment, so the two never stack.
- **Structure.** A declarative step model (`lib/onboardingSteps.ts`) names the real element to
  highlight via a `data-tour` attribute; an `OnboardingProvider` drives the step machine, navigation,
  and persistence; a `SpotlightOverlay` tracks the target across scroll/resize and routes; a
  `TourCard` positions the guidance with viewport-aware flipping. Accessible: focus moves to the card,
  it announces politely, and Escape exits from anywhere.

The change is organised as small, self-contained commits, each of which type-checks on its own:
engine → cross-page navigation → progress-awareness → first-visit welcome → motion/accessibility
polish, followed by review-driven fixes (keeping the progress poll and dataset check off the Hub,
scrolling below-the-fold targets into view, and a hint correction).

## Try it locally

```
lelab --dev
```

Open `http://localhost:8080`. To see the first-run welcome again after dismissing it, clear the flag
in the browser console and reload:

```
localStorage.removeItem("lelab:onboarding-v1"); location.reload()
```

## Testing

The backend change ships with `pytest` coverage (`tests/test_datasets.py`, `tests/test_server.py`):
the new local-only listing is tested for its `source="local"` tagging and, at the endpoint level, for
never reaching the Hub on `scope=local`. The full suite passes.

There is no frontend test harness in the repo, so the UI was verified with `tsc --noEmit`, ESLint,
`npm run build`, and a manual walkthrough via `lelab --dev`: first-run offer, per-step spotlight and
navigation (including scrolling below-the-fold targets into view), progress-driven auto-advance, the
skip/escape paths for hardware-free browsing, replay from both launchers, and behaviour under
resize/scroll. The UI is browser code with no OS-specific paths, so it behaves the same on Windows,
Linux, and macOS.