### PR TITLE
Add record/training pause-resume and dataset edit/merging/rerecord/re…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import Recording from "@/pages/Recording";
 import Training from "@/pages/Training";
 import Inference from "@/pages/Inference";
 import EditDataset from "@/pages/EditDataset";
+import RerecordEpisode from "@/pages/RerecordEpisode";
 import Upload from "@/pages/Upload";
 
 import NotFound from "@/pages/NotFound";
@@ -46,6 +47,7 @@ function App() {
                         <Route path="/inference" element={<Inference />} />
                         <Route path="/calibration" element={<Calibration />} />
                         <Route path="/edit-dataset" element={<EditDataset />} />
+                        <Route path="/rerecord" element={<RerecordEpisode />} />
 
                         <Route path="*" element={<NotFound />} />
                       </Routes>

--- a/frontend/src/lib/jobsApi.ts
+++ b/frontend/src/lib/jobsApi.ts
@@ -200,6 +200,28 @@ export async function stopJob(
   });
 }
 
+export async function pauseJob(
+  baseUrl: string,
+  fetcher: Fetcher,
+  id: string,
+): Promise<JobRecord> {
+  return apiRequest<JobRecord>(baseUrl, fetcher, `/jobs/${id}/pause`, {
+    method: "POST",
+    action: "Pause job",
+  });
+}
+
+export async function resumeJob(
+  baseUrl: string,
+  fetcher: Fetcher,
+  id: string,
+): Promise<JobRecord> {
+  return apiRequest<JobRecord>(baseUrl, fetcher, `/jobs/${id}/resume`, {
+    method: "POST",
+    action: "Resume job",
+  });
+}
+
 export async function deleteJob(
   baseUrl: string,
   fetcher: Fetcher,

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { ChevronsUpDown } from "lucide-react";
+import { ChevronsUpDown, Pencil, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import LandingTopBar from "@/components/landing/LandingTopBar";
@@ -265,6 +265,27 @@ const Landing = () => {
                   <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                 </Button>
               </DatasetPicker>
+            </div>
+            <div className="bg-gray-800 rounded-lg border border-gray-700 p-3 flex flex-col gap-2">
+              <h3 className="font-semibold text-lg text-left h-10 flex items-center">
+                Edit Datasets
+              </h3>
+              <Button
+                onClick={() => navigate("/edit-dataset")}
+                variant="outline"
+                className="w-full border-gray-600 text-gray-200 hover:bg-gray-700 hover:text-white"
+              >
+                <Pencil className="w-4 h-4 mr-2" />
+                Merge &amp; Edit
+              </Button>
+              <Button
+                onClick={() => navigate("/rerecord")}
+                variant="outline"
+                className="w-full border-gray-600 text-gray-200 hover:bg-gray-700 hover:text-white"
+              >
+                <RefreshCw className="w-4 h-4 mr-2" />
+                Add / Re-record
+              </Button>
             </div>
             <div className="bg-gray-800 rounded-lg border border-gray-700 p-3 flex flex-col gap-2">
               <h3 className="font-semibold text-lg text-left h-10 flex items-center">

--- a/frontend/src/pages/Recording.tsx
+++ b/frontend/src/pages/Recording.tsx
@@ -14,6 +14,7 @@ import {
   RotateCcw,
   Square,
   SkipForward,
+  Pause,
   Play,
   Volume2,
   VolumeX,
@@ -54,10 +55,11 @@ interface RecordingConfig {
   streaming_encoding: boolean;
 }
 
-type Phase = "preparing" | "recording" | "resetting" | "completed";
+type Phase = "preparing" | "recording" | "resetting" | "paused" | "completed";
 
 interface BackendStatus {
   recording_active: boolean;
+  recording_paused: boolean;
   current_phase: string;
   current_episode?: number;
   total_episodes?: number;
@@ -73,6 +75,8 @@ interface BackendStatus {
     stop_recording: boolean;
     exit_early: boolean;
     rerecord_episode: boolean;
+    pause_recording: boolean;
+    resume_recording: boolean;
   };
 }
 
@@ -243,23 +247,6 @@ const Recording = () => {
         }
 
         if (!status.recording_active && status.session_ended) {
-          // A failure can land after episodes were already saved, so surface
-          // the reason either way and only go home when nothing survived it.
-          if (status.current_phase === "error") {
-            const saved = status.saved_episodes || 0;
-            toast({
-              title: saved > 0 ? "Recording Interrupted" : "Recording Failed",
-              description:
-                saved > 0
-                  ? `${saved} episode(s) were saved before the session failed: ${status.error || "unknown error"}`
-                  : status.error || "The recording session failed to start.",
-              variant: "destructive",
-            });
-            if (saved === 0) {
-              navigate("/");
-              return;
-            }
-          }
           const datasetInfo = {
             dataset_repo_id:
               status.dataset_repo_id || recordingConfig.dataset_repo_id,
@@ -278,7 +265,7 @@ const Recording = () => {
     pollStatus();
     const statusInterval = setInterval(pollStatus, 1000);
     return () => clearInterval(statusInterval);
-  }, [recordingSessionStarted, recordingConfig, navigate, baseUrl, fetchWithHeaders, toast]);
+  }, [recordingSessionStarted, recordingConfig, navigate, baseUrl, fetchWithHeaders]);
 
   const formatTime = (seconds: number): string => {
     const mins = Math.floor(seconds / 60);
@@ -389,6 +376,26 @@ const Recording = () => {
         description: "Could not connect to the backend server.",
         variant: "destructive",
       });
+    }
+  }, [backendStatus, baseUrl, fetchWithHeaders, toast]);
+
+  const handlePauseRecording = useCallback(async () => {
+    if (!backendStatus?.available_controls.pause_recording) return;
+    try {
+      await fetchWithHeaders(`${baseUrl}/pause-recording`, { method: "POST" });
+      toast({ title: "Recording paused", description: "Current episode saved. Click Resume to continue." });
+    } catch {
+      toast({ title: "Error", description: "Failed to pause recording.", variant: "destructive" });
+    }
+  }, [backendStatus, baseUrl, fetchWithHeaders, toast]);
+
+  const handleResumeRecording = useCallback(async () => {
+    if (!backendStatus?.available_controls.resume_recording) return;
+    try {
+      await fetchWithHeaders(`${baseUrl}/resume-recording`, { method: "POST" });
+      toast({ title: "Recording resumed" });
+    } catch {
+      toast({ title: "Error", description: "Failed to resume recording.", variant: "destructive" });
     }
   }, [backendStatus, baseUrl, fetchWithHeaders, toast]);
 
@@ -510,6 +517,7 @@ const Recording = () => {
     if (currentPhase === "recording") return `RECORDING EPISODE ${currentEpisode}`;
     if (currentPhase === "resetting") return "RESET — GET READY";
     if (currentPhase === "preparing") return "PREPARING SESSION";
+    if (currentPhase === "paused") return "⏸ PAUSED — CLICK RESUME TO CONTINUE";
     return "SESSION COMPLETE";
   };
 
@@ -518,6 +526,8 @@ const Recording = () => {
       ? { dot: "bg-red-500", pill: "bg-red-500/15 text-red-300", timer: "text-green-400", bar: "bg-green-500", button: "bg-green-500 hover:bg-green-600" }
       : currentPhase === "resetting"
       ? { dot: "bg-orange-500", pill: "bg-orange-500/15 text-orange-300", timer: "text-orange-400", bar: "bg-orange-500", button: "bg-orange-500 hover:bg-orange-600" }
+      : currentPhase === "paused"
+      ? { dot: "bg-amber-400", pill: "bg-amber-400/15 text-amber-300", timer: "text-amber-400", bar: "bg-amber-400", button: "bg-amber-500 hover:bg-amber-600" }
       : { dot: "bg-gray-500", pill: "bg-gray-500/15 text-gray-300", timer: "text-gray-400", bar: "bg-gray-500", button: "bg-gray-500" };
 
   const primaryLabel =
@@ -560,6 +570,30 @@ const Recording = () => {
             >
               {muted ? <VolumeX className="w-5 h-5" /> : <Volume2 className="w-5 h-5" />}
             </Button>
+            {backendStatus.available_controls.pause_recording && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handlePauseRecording}
+                aria-label="Pause recording"
+                className="h-8 w-8 text-amber-400 hover:text-amber-300 hover:bg-gray-800"
+                title="Pause recording (saves current episode)"
+              >
+                <Pause className="w-5 h-5" />
+              </Button>
+            )}
+            {backendStatus.available_controls.resume_recording && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleResumeRecording}
+                aria-label="Resume recording"
+                className="h-8 w-8 text-green-400 hover:text-green-300 hover:bg-gray-800"
+                title="Resume recording"
+              >
+                <Play className="w-5 h-5" />
+              </Button>
+            )}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -703,6 +737,8 @@ const Recording = () => {
   );
 };
 
+export default Recording;
+
 interface CameraFeedProps {
   baseUrl: string;
   name: string;
@@ -774,5 +810,3 @@ const CameraFeed: React.FC<CameraFeedProps> = ({
     </div>
   );
 };
-
-export default Recording;

--- a/frontend/src/pages/RerecordEpisode.tsx
+++ b/frontend/src/pages/RerecordEpisode.tsx
@@ -1,0 +1,771 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  ArrowLeft,
+  Check,
+  Loader2,
+  Play,
+  Plus,
+  RefreshCw,
+  Trash2,
+  Video,
+  X,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { NumberInput } from "@/components/ui/number-input";
+import { useApi } from "@/contexts/ApiContext";
+import { useToast } from "@/hooks/use-toast";
+import { useRobots } from "@/hooks/useRobots";
+import CameraConfiguration, {
+  CameraConfig,
+} from "@/components/recording/CameraConfiguration";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface DatasetMeta {
+  repo_id: string;
+  num_episodes: number | null;
+  num_frames: number | null;
+  loadable: boolean;
+}
+
+interface EpisodeInfo {
+  episode_index: number;
+  length: number;
+  task: string;
+}
+
+interface CameraVideoInfo {
+  key: string;
+  rel_path: string;
+  from_timestamp: number;
+  to_timestamp: number;
+}
+
+// ─── Replay modal ─────────────────────────────────────────────────────────────
+
+function EpisodeReplayModal({
+  repoId,
+  episodeIndex,
+  baseUrl,
+  fetchWithHeaders,
+  onClose,
+}: {
+  repoId: string;
+  episodeIndex: number;
+  baseUrl: string;
+  fetchWithHeaders: typeof fetch;
+  onClose: () => void;
+}) {
+  const [cameras, setCameras] = useState<CameraVideoInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    fetchWithHeaders(
+      `${baseUrl}/dataset-episode-video-info?repo_id=${encodeURIComponent(repoId)}&episode_index=${episodeIndex}`
+    )
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.success) setCameras(data.cameras ?? []);
+        else setError(data.message ?? "Failed to load video info");
+      })
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false));
+  }, [repoId, episodeIndex, baseUrl, fetchWithHeaders]);
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="bg-gray-900 border-gray-700 text-white max-w-4xl w-full">
+        <DialogHeader>
+          <DialogTitle className="text-white flex items-center gap-2">
+            <Play className="w-4 h-4 text-green-400" />
+            Episode #{episodeIndex}
+          </DialogTitle>
+        </DialogHeader>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="w-6 h-6 animate-spin text-gray-400" />
+          </div>
+        ) : error ? (
+          <div className="text-red-400 text-sm py-4">{error}</div>
+        ) : cameras.length === 0 ? (
+          <div className="text-gray-400 text-sm py-4">No video found for this episode.</div>
+        ) : (
+          <div className={`grid gap-3 ${cameras.length > 1 ? "grid-cols-2" : "grid-cols-1"}`}>
+            {cameras.map((cam) => {
+              const shortKey = cam.key.split(".").pop() ?? cam.key;
+              const src = `${baseUrl}/dataset-video-file?repo_id=${encodeURIComponent(repoId)}&path=${encodeURIComponent(cam.rel_path)}#t=${cam.from_timestamp},${cam.to_timestamp}`;
+              return (
+                <div key={cam.key} className="rounded-lg overflow-hidden border border-gray-700">
+                  <video
+                    src={src}
+                    controls
+                    autoPlay
+                    loop
+                    muted
+                    playsInline
+                    className="w-full bg-black"
+                    style={{ maxHeight: "360px" }}
+                    onLoadedMetadata={(e) => {
+                      // Seek to start of episode segment
+                      const v = e.currentTarget;
+                      v.currentTime = cam.from_timestamp;
+                    }}
+                    onTimeUpdate={(e) => {
+                      // Loop within the episode segment
+                      const v = e.currentTarget;
+                      if (v.currentTime >= cam.to_timestamp) {
+                        v.currentTime = cam.from_timestamp;
+                      }
+                    }}
+                  />
+                  <div className="px-2 py-1 text-xs text-gray-400 bg-gray-800">
+                    {shortKey} &nbsp;·&nbsp; {(cam.to_timestamp - cam.from_timestamp).toFixed(1)}s
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─── Sub-components ──────────────────────────────────────────────────────────
+
+function EpisodeCard({
+  ep,
+  selected,
+  onToggle,
+  onPlay,
+}: {
+  ep: EpisodeInfo;
+  selected: boolean;
+  onToggle: () => void;
+  onPlay: () => void;
+}) {
+  return (
+    <div
+      className={`w-full text-left rounded-lg border px-3 py-2 transition-colors ${
+        selected
+          ? "border-red-500 bg-red-500/10"
+          : "border-gray-700 bg-gray-800 hover:border-gray-500"
+      }`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <button onClick={onToggle} className="flex items-center gap-2 min-w-0 flex-1">
+          <div
+            className={`flex-shrink-0 w-4 h-4 rounded border flex items-center justify-center ${
+              selected ? "border-red-500 bg-red-500" : "border-gray-500"
+            }`}
+          >
+            {selected && <Check className="w-3 h-3 text-white" />}
+          </div>
+          <span className="font-mono text-sm text-white">
+            #{ep.episode_index}
+          </span>
+        </button>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <span className="text-xs text-gray-400">{ep.length} frames</span>
+          <button
+            onClick={(e) => { e.stopPropagation(); onPlay(); }}
+            className="p-1 rounded hover:bg-green-500/20 text-green-400 transition-colors"
+            title="Replay episode"
+          >
+            <Play className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+      {ep.task && (
+        <p className="text-xs text-gray-500 mt-1 ml-6 truncate">{ep.task}</p>
+      )}
+    </div>
+  );
+}
+
+// ─── Main Page ────────────────────────────────────────────────────────────────
+
+const RerecordEpisode: React.FC = () => {
+  const navigate = useNavigate();
+  const { baseUrl, fetchWithHeaders } = useApi();
+  const { toast } = useToast();
+  const { selectedRecord, availableNames, records, selectRobot, isLoading: robotsLoading } = useRobots();
+
+  // ── Dataset selection ──
+  const [datasets, setDatasets] = useState<DatasetMeta[]>([]);
+  const [datasetsLoading, setDatasetsLoading] = useState(false);
+  const [selectedDataset, setSelectedDataset] = useState<string | null>(null);
+
+  // ── Episode list ──
+  const [episodes, setEpisodes] = useState<EpisodeInfo[]>([]);
+  const [episodesLoading, setEpisodesLoading] = useState(false);
+  const [selectedEpisodes, setSelectedEpisodes] = useState<Set<number>>(new Set());
+  const [replayEpisodeIndex, setReplayEpisodeIndex] = useState<number | null>(null);
+
+  // ── Recording config ──
+  const [singleTask, setSingleTask] = useState("");
+  const [numNewEpisodes, setNumNewEpisodes] = useState(1);
+  const [episodeTimeS, setEpisodeTimeS] = useState(60);
+  const [resetTimeS, setResetTimeS] = useState(15);
+  const [cameras, setCameras] = useState<CameraConfig[]>([]);
+
+  // ── Action state ──
+  const [working, setWorking] = useState(false);
+  const releaseStreamsRef = useRef<(() => void) | null>(null);
+
+  // Load datasets on mount
+  useEffect(() => {
+    setDatasetsLoading(true);
+    fetchWithHeaders(`${baseUrl}/edit/datasets`)
+      .then((r) => r.json())
+      .then((data: DatasetMeta[]) =>
+        setDatasets(data.filter((d) => d.loadable && (d.num_episodes ?? 0) > 0))
+      )
+      .catch((e) => console.error("Failed to load datasets:", e))
+      .finally(() => setDatasetsLoading(false));
+  }, [baseUrl, fetchWithHeaders]);
+
+  // Load episode list when dataset is selected
+  const loadEpisodes = useCallback(
+    (repoId: string) => {
+      setEpisodesLoading(true);
+      setEpisodes([]);
+      setSelectedEpisodes(new Set());
+      fetchWithHeaders(
+        `${baseUrl}/dataset-episodes?repo_id=${encodeURIComponent(repoId)}`
+      )
+        .then((r) => r.json())
+        .then((data) => {
+          if (data.success) setEpisodes(data.episodes ?? []);
+          else
+            toast({
+              title: "Could not load episodes",
+              description: data.message,
+              variant: "destructive",
+            });
+        })
+        .catch((e) =>
+          toast({
+            title: "Error",
+            description: String(e),
+            variant: "destructive",
+          })
+        )
+        .finally(() => setEpisodesLoading(false));
+    },
+    [baseUrl, fetchWithHeaders, toast]
+  );
+
+  const handleSelectDataset = useCallback(
+    (repoId: string) => {
+      setSelectedDataset(repoId);
+      loadEpisodes(repoId);
+      // Pre-fill task from dataset episodes if available
+    },
+    [loadEpisodes]
+  );
+
+  // Sync cameras from robot profile when robot changes
+  useEffect(() => {
+    setCameras(selectedRecord ? [...(selectedRecord.cameras ?? [])] : []);
+  }, [selectedRecord]);
+
+  // Sync task from first episode
+  useEffect(() => {
+    if (episodes.length > 0 && !singleTask) {
+      const firstTask = episodes[0].task;
+      if (firstTask) setSingleTask(firstTask);
+    }
+  }, [episodes, singleTask]);
+
+  const toggleEpisode = useCallback((idx: number) => {
+    setSelectedEpisodes((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  }, []);
+
+  const selectAll = useCallback(() => {
+    setSelectedEpisodes(new Set(episodes.map((e) => e.episode_index)));
+  }, [episodes]);
+
+  const clearAll = useCallback(() => {
+    setSelectedEpisodes(new Set());
+  }, []);
+
+  // Total episodes that will be recorded = selected (to replace) + extra new ones
+  const totalToRecord = selectedEpisodes.size > 0 ? selectedEpisodes.size + (numNewEpisodes - selectedEpisodes.size > 0 ? numNewEpisodes - selectedEpisodes.size : 0) : numNewEpisodes;
+
+  const canStart =
+    !!selectedDataset &&
+    !!selectedRecord &&
+    selectedRecord.is_clean &&
+    !!singleTask.trim() &&
+    !working;
+
+  const handleStart = useCallback(async () => {
+    if (!selectedDataset || !selectedRecord) return;
+
+    setWorking(true);
+
+    try {
+      // Step 1: Delete selected episodes in-place (if any)
+      if (selectedEpisodes.size > 0) {
+        const resp = await fetchWithHeaders(
+          `${baseUrl}/edit/delete-episodes-inplace`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              dataset_repo_id: selectedDataset,
+              episode_indices: Array.from(selectedEpisodes),
+            }),
+          }
+        );
+        const data = await resp.json();
+        if (!data.success) {
+          toast({
+            title: "Delete failed",
+            description: data.message,
+            variant: "destructive",
+          });
+          setWorking(false);
+          return;
+        }
+        toast({
+          title: "Episodes deleted",
+          description: data.message,
+        });
+      }
+
+      // Step 2: Build recording config and navigate to Recording page
+      const cameraDict = cameras.reduce(
+        (acc, cam) => {
+          acc[cam.name] = {
+            type: cam.type,
+            camera_index: cam.camera_index,
+            width: cam.width,
+            height: cam.height,
+            fps: cam.fps,
+            ...(cam.fourcc ? { fourcc: cam.fourcc } : {}),
+            ...(cam.backend ? { backend: cam.backend } : {}),
+          };
+          return acc;
+        },
+        {} as Record<string, unknown>
+      );
+
+      const nToRecord =
+        selectedEpisodes.size > 0
+          ? Math.max(selectedEpisodes.size, numNewEpisodes)
+          : numNewEpisodes;
+
+      const recordingConfig = {
+        leader_port: selectedRecord.leader_port,
+        follower_port: selectedRecord.follower_port,
+        leader_config: selectedRecord.leader_config,
+        follower_config: selectedRecord.follower_config,
+        dataset_repo_id: selectedDataset,
+        single_task: singleTask.trim(),
+        num_episodes: nToRecord,
+        episode_time_s: episodeTimeS,
+        reset_time_s: resetTimeS,
+        fps: 30,
+        video: true,
+        push_to_hub: false,
+        resume: true,
+        streaming_encoding: true,
+        cameras: cameraDict,
+      };
+
+      // Release any camera preview streams before navigation
+      if (releaseStreamsRef.current) releaseStreamsRef.current();
+
+      navigate("/recording", { state: { recordingConfig } });
+    } catch (e) {
+      toast({ title: "Error", description: String(e), variant: "destructive" });
+      setWorking(false);
+    }
+  }, [
+    selectedDataset,
+    selectedRecord,
+    selectedEpisodes,
+    cameras,
+    numNewEpisodes,
+    singleTask,
+    episodeTimeS,
+    resetTimeS,
+    baseUrl,
+    fetchWithHeaders,
+    navigate,
+    toast,
+  ]);
+
+  const shortId = (r: string) =>
+    r.includes("/") ? r.split("/")[1] : r;
+
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <div className="max-w-5xl mx-auto">
+        {/* Header */}
+        <div className="mb-6 flex items-center gap-4">
+          <Button
+            variant="outline"
+            onClick={() => navigate("/")}
+            className="border-gray-500 hover:border-gray-200 text-gray-300 hover:text-white"
+          >
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            Back
+          </Button>
+          <div>
+            <h1 className="text-2xl font-bold text-white">Add / Re-record Episodes</h1>
+            <p className="text-sm text-gray-400 mt-0.5">
+              Delete bad demonstrations and record replacements, or append new
+              episodes to an existing dataset.
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* Left column: dataset + episode selection */}
+          <div className="space-y-4">
+            {/* Dataset picker */}
+            <div className="bg-gray-900 rounded-lg border border-gray-700 p-4">
+              <h2 className="font-semibold text-white mb-3 flex items-center gap-2">
+                <Video className="w-4 h-4 text-gray-400" />
+                Select Dataset
+              </h2>
+              {datasetsLoading ? (
+                <div className="flex items-center gap-2 text-gray-400 text-sm">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Loading datasets…
+                </div>
+              ) : datasets.length === 0 ? (
+                <p className="text-gray-500 text-sm">No local datasets found.</p>
+              ) : (
+                <Select
+                  value={selectedDataset ?? ""}
+                  onValueChange={handleSelectDataset}
+                >
+                  <SelectTrigger className="bg-gray-800 border-gray-600 text-white">
+                    <SelectValue placeholder="Choose a dataset…" />
+                  </SelectTrigger>
+                  <SelectContent className="bg-gray-800 border-gray-700 text-white">
+                    {datasets.map((ds) => (
+                      <SelectItem
+                        key={ds.repo_id}
+                        value={ds.repo_id}
+                        className="focus:bg-gray-700 focus:text-white"
+                      >
+                        <span className="font-medium">{shortId(ds.repo_id)}</span>
+                        {ds.num_episodes !== null && (
+                          <span className="ml-2 text-gray-400 text-xs">
+                            ({ds.num_episodes} ep)
+                          </span>
+                        )}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+              {selectedDataset && (
+                <p className="mt-1 text-xs text-gray-500 font-mono">{selectedDataset}</p>
+              )}
+            </div>
+
+            {/* Episode list */}
+            {selectedDataset && (
+              <div className="bg-gray-900 rounded-lg border border-gray-700 p-4">
+                <div className="flex items-center justify-between mb-3">
+                  <h2 className="font-semibold text-white flex items-center gap-2">
+                    <Trash2 className="w-4 h-4 text-red-400" />
+                    Episodes to Delete
+                    {selectedEpisodes.size > 0 && (
+                      <Badge className="bg-red-500/20 text-red-300 border-red-500/30 text-xs">
+                        {selectedEpisodes.size} selected
+                      </Badge>
+                    )}
+                  </h2>
+                  <div className="flex gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => loadEpisodes(selectedDataset)}
+                      className="text-gray-400 hover:text-white h-7 px-2"
+                      title="Refresh"
+                    >
+                      <RefreshCw className="w-3 h-3" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={selectAll}
+                      className="text-gray-400 hover:text-white h-7 px-2 text-xs"
+                    >
+                      All
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={clearAll}
+                      className="text-gray-400 hover:text-white h-7 px-2 text-xs"
+                    >
+                      None
+                    </Button>
+                  </div>
+                </div>
+
+                {episodesLoading ? (
+                  <div className="flex items-center gap-2 text-gray-400 text-sm py-4">
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Loading episodes…
+                  </div>
+                ) : episodes.length === 0 ? (
+                  <p className="text-gray-500 text-sm">No episodes found.</p>
+                ) : (
+                  <div className="grid grid-cols-2 gap-1.5 max-h-72 overflow-y-auto pr-1">
+                    {episodes.map((ep) => (
+                      <EpisodeCard
+                        key={ep.episode_index}
+                        ep={ep}
+                        selected={selectedEpisodes.has(ep.episode_index)}
+                        onToggle={() => toggleEpisode(ep.episode_index)}
+                        onPlay={() => setReplayEpisodeIndex(ep.episode_index)}
+                      />
+                    ))}
+                  </div>
+                )}
+
+                {selectedEpisodes.size > 0 && (
+                  <p className="mt-3 text-xs text-red-400/80 flex items-center gap-1">
+                    <Trash2 className="w-3 h-3" />
+                    {selectedEpisodes.size} episode(s) will be permanently
+                    deleted before recording starts.
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Right column: recording config */}
+          <div className="space-y-4">
+            {/* Robot selection */}
+            <div className="bg-gray-900 rounded-lg border border-gray-700 p-4">
+              <h2 className="font-semibold text-white mb-3">Robot</h2>
+              {robotsLoading ? (
+                <div className="flex items-center gap-2 text-gray-400 text-sm">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Loading robots…
+                </div>
+              ) : availableNames.length === 0 ? (
+                <p className="text-gray-500 text-sm">
+                  No robots configured. Set one up on the Landing page first.
+                </p>
+              ) : (
+                <Select
+                  value={selectedRecord?.name ?? ""}
+                  onValueChange={selectRobot}
+                >
+                  <SelectTrigger className="bg-gray-800 border-gray-600 text-white">
+                    <SelectValue placeholder="Choose a robot…" />
+                  </SelectTrigger>
+                  <SelectContent className="bg-gray-800 border-gray-700 text-white">
+                    {availableNames.map((name) => (
+                      <SelectItem
+                        key={name}
+                        value={name}
+                        className="focus:bg-gray-700 focus:text-white"
+                      >
+                        {name}
+                        {!records[name]?.is_clean && (
+                          <span className="ml-2 text-amber-400 text-xs">
+                            (needs calibration)
+                          </span>
+                        )}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+              {selectedRecord && !selectedRecord.is_clean && (
+                <p className="mt-2 text-xs text-amber-400">
+                  This robot needs calibration before recording.
+                </p>
+              )}
+            </div>
+
+            {/* Recording parameters */}
+            <div className="bg-gray-900 rounded-lg border border-gray-700 p-4 space-y-4">
+              <h2 className="font-semibold text-white">Recording Parameters</h2>
+
+              <div className="space-y-1.5">
+                <Label className="text-sm text-gray-300">Task Description *</Label>
+                <Input
+                  value={singleTask}
+                  onChange={(e) => setSingleTask(e.target.value)}
+                  placeholder="e.g., pick and place the rubber object"
+                  className="bg-gray-800 border-gray-700 text-white"
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label className="text-sm text-gray-300">
+                  Episodes to record{" "}
+                  {selectedEpisodes.size > 0 && (
+                    <span className="text-gray-500">
+                      (min {selectedEpisodes.size} to replace deleted)
+                    </span>
+                  )}
+                </Label>
+                <NumberInput
+                  min={selectedEpisodes.size > 0 ? selectedEpisodes.size : 1}
+                  value={numNewEpisodes}
+                  onChange={(v) => {
+                    if (v !== undefined) setNumNewEpisodes(v);
+                  }}
+                  className="bg-gray-800 border-gray-700 text-white"
+                />
+                {selectedEpisodes.size > 0 && numNewEpisodes < selectedEpisodes.size && (
+                  <p className="text-xs text-amber-400">
+                    Will record {selectedEpisodes.size} episodes to replace the
+                    deleted ones.
+                  </p>
+                )}
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label className="text-sm text-gray-300">
+                    Episode duration (s)
+                  </Label>
+                  <NumberInput
+                    min={1}
+                    value={episodeTimeS}
+                    onChange={(v) => {
+                      if (v !== undefined) setEpisodeTimeS(v);
+                    }}
+                    className="bg-gray-800 border-gray-700 text-white"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label className="text-sm text-gray-300">
+                    Reset duration (s)
+                  </Label>
+                  <NumberInput
+                    min={1}
+                    value={resetTimeS}
+                    onChange={(v) => {
+                      if (v !== undefined) setResetTimeS(v);
+                    }}
+                    className="bg-gray-800 border-gray-700 text-white"
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* Cameras */}
+            <div className="bg-gray-900 rounded-lg border border-gray-700 p-4">
+              <CameraConfiguration
+                cameras={cameras}
+                onCamerasChange={setCameras}
+                releaseStreamsRef={releaseStreamsRef}
+                readOnly
+              />
+              <p className="text-xs text-gray-500 mt-2">
+                Cameras are taken from the selected robot profile.
+              </p>
+            </div>
+
+            {/* Action */}
+            <div className="bg-gray-900 rounded-lg border border-gray-700 p-4">
+              <div className="mb-3 text-sm text-gray-400">
+                {selectedEpisodes.size > 0 ? (
+                  <span>
+                    Will delete{" "}
+                    <span className="text-red-400 font-semibold">
+                      {selectedEpisodes.size}
+                    </span>{" "}
+                    episode(s), then record{" "}
+                    <span className="text-green-400 font-semibold">
+                      {Math.max(selectedEpisodes.size, numNewEpisodes)}
+                    </span>{" "}
+                    new episode(s).
+                  </span>
+                ) : (
+                  <span>
+                    Will append{" "}
+                    <span className="text-green-400 font-semibold">
+                      {numNewEpisodes}
+                    </span>{" "}
+                    new episode(s) to the selected dataset.
+                  </span>
+                )}
+              </div>
+              <Button
+                onClick={handleStart}
+                disabled={!canStart}
+                className="w-full bg-red-500 hover:bg-red-600 text-white font-semibold py-5 text-base disabled:opacity-40"
+              >
+                {working ? (
+                  <Loader2 className="w-5 h-5 animate-spin mr-2" />
+                ) : (
+                  <Plus className="w-5 h-5 mr-2" />
+                )}
+                {working
+                  ? "Preparing…"
+                  : selectedEpisodes.size > 0
+                  ? `Delete & Record`
+                  : `Record New Episodes`}
+              </Button>
+              {!selectedRecord && (
+                <p className="text-xs text-amber-400 mt-2 text-center">
+                  Select a configured robot to enable recording.
+                </p>
+              )}
+              {!selectedDataset && (
+                <p className="text-xs text-gray-500 mt-2 text-center">
+                  Select a dataset to start.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {replayEpisodeIndex !== null && selectedDataset && (
+        <EpisodeReplayModal
+          repoId={selectedDataset}
+          episodeIndex={replayEpisodeIndex}
+          baseUrl={baseUrl}
+          fetchWithHeaders={fetchWithHeaders}
+          onClose={() => setReplayEpisodeIndex(null)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default RerecordEpisode;

--- a/frontend/src/pages/Training.tsx
+++ b/frontend/src/pages/Training.tsx
@@ -15,7 +15,7 @@ import HfAuthBanner from "@/components/landing/HfAuthBanner";
 
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
-import { Loader2, Play, Square, Trash2, ArrowLeft } from "lucide-react";
+import { Loader2, Pause, Play, Square, Trash2, ArrowLeft } from "lucide-react";
 
 import { DatasetItem, listDatasets } from "@/lib/replayApi";
 import {
@@ -27,6 +27,8 @@ import {
   listJobs,
   startTrainingJob,
   stopJob,
+  pauseJob,
+  resumeJob,
   deleteJob,
   listRunnerHardware,
   RunnerFlavor,
@@ -50,7 +52,7 @@ function jobToStatus(job: JobRecord | null, isStarting: boolean): TrainingStatus
     };
   }
   return {
-    training_active: job.state === "running",
+    training_active: job.state === "running" || job.state === "paused",
     current_step: job.metrics.current_step,
     total_steps: job.metrics.total_steps,
     current_loss: job.metrics.current_loss ?? undefined,
@@ -58,9 +60,9 @@ function jobToStatus(job: JobRecord | null, isStarting: boolean): TrainingStatus
     grad_norm: job.metrics.grad_norm ?? undefined,
     eta_seconds: job.metrics.eta_seconds ?? undefined,
     available_controls: {
-      stop_training: job.state === "running",
-      pause_training: false,
-      resume_training: false,
+      stop_training: job.state === "running" || job.state === "paused",
+      pause_training: job.state === "running",
+      resume_training: job.state === "paused",
     },
   };
 }
@@ -421,7 +423,7 @@ const MonitoringMode: React.FC<{ jobId: string }> = ({ jobId }) => {
     tick();
     const id = setInterval(() => {
       if (cancelled) return;
-      if (jobStateRef.current && jobStateRef.current !== "running") return;
+      if (jobStateRef.current && jobStateRef.current !== "running" && jobStateRef.current !== "paused") return;
       tick();
     }, 5000);
     return () => {
@@ -456,7 +458,7 @@ const MonitoringMode: React.FC<{ jobId: string }> = ({ jobId }) => {
     tick();
     const id = setInterval(() => {
       if (cancelled) return;
-      if (jobStateRef.current && jobStateRef.current !== "running") return;
+      if (jobStateRef.current && jobStateRef.current !== "running" && jobStateRef.current !== "paused") return;
       tick();
     }, POLL_INTERVAL_MS);
     return () => {
@@ -496,6 +498,36 @@ const MonitoringMode: React.FC<{ jobId: string }> = ({ jobId }) => {
     } catch (e) {
       toast({
         title: "Stop failed",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handlePause = async () => {
+    if (!job) return;
+    try {
+      const next = await pauseJob(baseUrl, fetchWithHeaders, job.id);
+      setJob(next);
+      toast({ title: "Training paused" });
+    } catch (e) {
+      toast({
+        title: "Pause failed",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleResume = async () => {
+    if (!job) return;
+    try {
+      const next = await resumeJob(baseUrl, fetchWithHeaders, job.id);
+      setJob(next);
+      toast({ title: "Training resumed" });
+    } catch (e) {
+      toast({
+        title: "Resume failed",
         description: e instanceof Error ? e.message : String(e),
         variant: "destructive",
       });
@@ -542,6 +574,8 @@ const MonitoringMode: React.FC<{ jobId: string }> = ({ jobId }) => {
   }
 
   const isRunning = job.state === "running";
+  const isPaused = job.state === "paused";
+  const isActive = isRunning || isPaused;
 
   return (
     <div className="min-h-screen bg-slate-900 text-white p-4">
@@ -590,10 +624,21 @@ const MonitoringMode: React.FC<{ jobId: string }> = ({ jobId }) => {
               </p>
             </div>
           </div>
-          {isRunning ? (
-            <Button onClick={handleStop} className="bg-red-500 hover:bg-red-600 text-white">
-              <Square className="w-4 h-4 mr-2" /> Stop
-            </Button>
+          {isActive ? (
+            <div className="flex items-center gap-2">
+              {isPaused ? (
+                <Button onClick={handleResume} className="bg-green-600 hover:bg-green-700 text-white">
+                  <Play className="w-4 h-4 mr-2" /> Resume
+                </Button>
+              ) : (
+                <Button onClick={handlePause} className="bg-amber-600 hover:bg-amber-700 text-white">
+                  <Pause className="w-4 h-4 mr-2" /> Pause
+                </Button>
+              )}
+              <Button onClick={handleStop} className="bg-red-500 hover:bg-red-600 text-white">
+                <Square className="w-4 h-4 mr-2" /> Stop
+              </Button>
+            </div>
           ) : (
             <Button onClick={handleDelete} variant="ghost" className="text-slate-400 hover:text-white">
               <Trash2 className="w-4 h-4 mr-2" /> Delete

--- a/lelab/dataset_edit.py
+++ b/lelab/dataset_edit.py
@@ -1,0 +1,374 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dataset editing operations: merge and delete episodes."""
+
+import logging
+import threading
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+# ── Merge job state ────────────────────────────────────────────────────────────
+
+_merge_lock = threading.Lock()
+_merge_state: dict[str, Any] = {
+    "running": False,
+    "success": None,
+    "message": "Idle",
+    "progress": "idle",
+    "output_repo_id": None,
+    "steps": [],
+}
+
+
+# ── Request models ─────────────────────────────────────────────────────────────
+
+class MergeRequest(BaseModel):
+    source_repo_ids: list[str]
+    output_repo_id: str
+
+
+class DeleteEpisodesRequest(BaseModel):
+    dataset_repo_id: str
+    episode_indices: list[int]
+    output_repo_id: str | None = None
+
+
+class DeleteEpisodesInplaceRequest(BaseModel):
+    dataset_repo_id: str
+    episode_indices: list[int]
+
+
+# ── Handlers ───────────────────────────────────────────────────────────────────
+
+def handle_get_editable_datasets() -> list[dict[str, Any]]:
+    """List local datasets enriched with episode / frame counts."""
+    from .datasets import list_local_datasets
+
+    raw = list_local_datasets()
+    result: list[dict[str, Any]] = []
+    for ds in raw:
+        repo_id = ds["repo_id"]
+        try:
+            from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+            dataset = LeRobotDataset(repo_id)
+            tasks: list[str] = []
+            if hasattr(dataset.meta, "tasks") and dataset.meta.tasks is not None:
+                t = dataset.meta.tasks
+                import pandas as pd
+                if isinstance(t, pd.DataFrame) and not t.empty:
+                    tasks = list(t.index.tolist())
+                elif isinstance(t, dict) and t:
+                    tasks = list(t.values())
+            result.append(
+                {
+                    **ds,
+                    "num_episodes": dataset.num_episodes,
+                    "num_frames": dataset.num_frames,
+                    "fps": dataset.fps,
+                    "robot_type": getattr(dataset.meta, "robot_type", None),
+                    "tasks": tasks,
+                    "loadable": True,
+                }
+            )
+        except Exception as e:
+            logger.debug(f"Could not load dataset {repo_id}: {e}")
+            result.append({**ds, "num_episodes": None, "num_frames": None, "fps": None, "robot_type": None, "tasks": [], "loadable": False})
+    return result
+
+
+def handle_start_merge(request: MergeRequest) -> dict[str, Any]:
+    """Start a background merge of *source_repo_ids* into *output_repo_id*."""
+    global _merge_state
+
+    if len(request.source_repo_ids) < 2:
+        return {"success": False, "message": "Select at least 2 datasets to merge."}
+
+    with _merge_lock:
+        if _merge_state["running"]:
+            return {"success": False, "message": "A merge is already running. Wait for it to finish."}
+        _merge_state = {
+            "running": True,
+            "success": None,
+            "message": "Starting…",
+            "progress": "starting",
+            "output_repo_id": request.output_repo_id,
+            "steps": [],
+        }
+
+    thread = threading.Thread(
+        target=_run_merge,
+        args=(request.source_repo_ids, request.output_repo_id),
+        daemon=True,
+        name="lelab-merge",
+    )
+    thread.start()
+    return {"success": True, "message": "Merge started."}
+
+
+def handle_merge_status() -> dict[str, Any]:
+    with _merge_lock:
+        return dict(_merge_state)
+
+
+def handle_delete_episodes(request: DeleteEpisodesRequest) -> dict[str, Any]:
+    """Delete episodes from a dataset; result is saved as a new dataset."""
+    try:
+        from lerobot.datasets.dataset_tools import delete_episodes
+        from lerobot.datasets.lerobot_dataset import LeRobotDataset
+        from lerobot.utils.constants import HF_LEROBOT_HOME
+
+        dataset = LeRobotDataset(request.dataset_repo_id)
+
+        output_repo_id = request.output_repo_id or f"{request.dataset_repo_id}_cleaned"
+        output_dir = Path(HF_LEROBOT_HOME) / output_repo_id
+
+        delete_episodes(
+            dataset=dataset,
+            episode_indices=request.episode_indices,
+            output_dir=output_dir,
+            repo_id=output_repo_id,
+        )
+        return {
+            "success": True,
+            "message": (
+                f"Deleted {len(request.episode_indices)} episode(s) from "
+                f"'{request.dataset_repo_id}'. "
+                f"New dataset saved as '{output_repo_id}'."
+            ),
+            "output_repo_id": output_repo_id,
+        }
+    except Exception as e:
+        logger.error(f"Delete episodes failed: {e}")
+        return {"success": False, "message": str(e)}
+
+
+def handle_get_episode_video_info(repo_id: str, episode_index: int) -> dict[str, Any]:
+    """Return video file paths and timestamps for a single episode.
+
+    The frontend uses these to build video src URLs (with #t=from,to fragments
+    so the browser plays only the episode's segment inside the shared mp4).
+    """
+    try:
+        from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+        dataset = LeRobotDataset(repo_id)
+        eps = dataset.meta.episodes
+        if episode_index >= len(eps):
+            return {"success": False, "message": f"Episode {episode_index} not found"}
+        row = eps[episode_index]
+
+        # Extract video keys from column names: "videos/{key}/from_timestamp"
+        video_keys = sorted({
+            col.split("/", 2)[1]
+            for col in eps.column_names
+            if col.startswith("videos/") and col.endswith("/from_timestamp")
+        })
+
+        cameras: list[dict[str, Any]] = []
+        for key in video_keys:
+            chunk_idx = int(row[f"videos/{key}/chunk_index"])
+            file_idx = int(row[f"videos/{key}/file_index"])
+            from_ts = float(row[f"videos/{key}/from_timestamp"])
+            to_ts = float(row[f"videos/{key}/to_timestamp"])
+            rel_path = f"videos/{key}/chunk-{chunk_idx:03d}/file-{file_idx:03d}.mp4"
+            cameras.append({
+                "key": key,
+                "rel_path": rel_path,
+                "from_timestamp": from_ts,
+                "to_timestamp": to_ts,
+            })
+
+        return {"success": True, "cameras": cameras, "episode_index": episode_index}
+    except Exception as e:
+        logger.error(f"get_episode_video_info failed: {e}")
+        return {"success": False, "message": str(e), "cameras": []}
+
+
+def handle_serve_video_file(repo_id: str, rel_path: str) -> Path:
+    """Resolve and validate a video file path inside a local dataset root.
+
+    Returns the absolute Path if safe; raises ValueError on path traversal.
+    """
+    from lerobot.utils.constants import HF_LEROBOT_HOME
+
+    root = Path(HF_LEROBOT_HOME).resolve()
+    dataset_root = (root / repo_id).resolve()
+    target = (dataset_root / rel_path).resolve()
+
+    # Reject path traversal: target must be strictly inside the dataset root
+    if root not in target.parents and dataset_root not in target.parents:
+        raise ValueError(f"Path traversal attempt: {rel_path}")
+    if not target.exists():
+        raise FileNotFoundError(f"Video not found: {rel_path}")
+    return target
+
+
+def handle_get_episodes(repo_id: str) -> dict[str, Any]:
+    """Return the episode list for a local dataset (index, length, task)."""
+    try:
+        from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+        dataset = LeRobotDataset(repo_id)
+        eps = dataset.meta.episodes
+        episodes: list[dict[str, Any]] = []
+        for i in range(len(eps)):
+            row = eps[i]
+            task_list = row.get("tasks", []) or []
+            if not isinstance(task_list, list):
+                task_list = [str(task_list)]
+            episodes.append({
+                "episode_index": int(row["episode_index"]),
+                "length": int(row["length"]),
+                "task": task_list[0] if task_list else "",
+            })
+        return {
+            "success": True,
+            "episodes": episodes,
+            "num_episodes": dataset.num_episodes,
+        }
+    except Exception as e:
+        logger.error(f"get_episodes failed for {repo_id}: {e}")
+        return {"success": False, "message": str(e), "episodes": []}
+
+
+def handle_delete_episodes_inplace(request: DeleteEpisodesInplaceRequest) -> dict[str, Any]:
+    """Delete episodes from a dataset and replace the dataset in-place.
+
+    Reads from the source, writes to a temp directory, then atomically
+    replaces the source with the cleaned copy (same repo_id / root path).
+    """
+    import shutil
+
+    from lerobot.datasets.dataset_tools import delete_episodes
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+    from lerobot.utils.constants import HF_LEROBOT_HOME
+
+    try:
+        root = Path(HF_LEROBOT_HOME)
+        source_dir = root / request.dataset_repo_id
+        if not source_dir.exists():
+            return {"success": False, "message": f"Dataset not found: {request.dataset_repo_id}"}
+
+        # Write cleaned copy into a sibling temp dir (same filesystem → move is atomic)
+        owner, name = (request.dataset_repo_id.split("/", 1) + [""])[:2]
+        temp_dir = root / owner / f"_temp_rerecord_{name}" if owner else root / f"_temp_rerecord_{name}"
+        if temp_dir.exists():
+            shutil.rmtree(temp_dir)
+
+        dataset = LeRobotDataset(request.dataset_repo_id)
+        original_total = dataset.num_episodes
+
+        delete_episodes(
+            dataset=dataset,
+            episode_indices=request.episode_indices,
+            output_dir=temp_dir,
+            repo_id=request.dataset_repo_id,
+        )
+
+        # Swap: move original aside, move cleaned into its place, clean up
+        backup_dir = source_dir.parent / f"_backup_{source_dir.name}"
+        if backup_dir.exists():
+            shutil.rmtree(backup_dir)
+        shutil.move(str(source_dir), str(backup_dir))
+        shutil.move(str(temp_dir), str(source_dir))
+        shutil.rmtree(backup_dir)
+
+        remaining = original_total - len(request.episode_indices)
+        return {
+            "success": True,
+            "message": (
+                f"Deleted {len(request.episode_indices)} episode(s). "
+                f"Dataset now has {remaining} episode(s)."
+            ),
+            "dataset_repo_id": request.dataset_repo_id,
+            "num_episodes_remaining": remaining,
+        }
+    except Exception as e:
+        logger.error(f"delete_episodes_inplace failed: {e}", exc_info=True)
+        # Clean up temp dir if it exists
+        try:
+            if temp_dir.exists():
+                shutil.rmtree(temp_dir)
+        except Exception:
+            pass
+        return {"success": False, "message": str(e)}
+
+
+# ── Internal helpers ───────────────────────────────────────────────────────────
+
+def _log_step(msg: str) -> None:
+    logger.info(f"[merge] {msg}")
+    with _merge_lock:
+        _merge_state["message"] = msg
+        _merge_state["steps"].append(msg)
+
+
+def _run_merge(source_repo_ids: list[str], output_repo_id: str) -> None:
+    global _merge_state
+    try:
+        from lerobot.datasets.dataset_tools import merge_datasets
+        from lerobot.datasets.lerobot_dataset import LeRobotDataset
+        from lerobot.utils.constants import HF_LEROBOT_HOME
+
+        with _merge_lock:
+            _merge_state["progress"] = "loading"
+
+        datasets: list[LeRobotDataset] = []
+        for repo_id in source_repo_ids:
+            _log_step(f"Loading dataset '{repo_id}'…")
+            datasets.append(LeRobotDataset(repo_id))
+
+        output_dir = Path(HF_LEROBOT_HOME) / output_repo_id
+        _log_step(f"Merging {len(datasets)} datasets → '{output_repo_id}'…")
+
+        with _merge_lock:
+            _merge_state["progress"] = "merging"
+
+        merge_datasets(
+            datasets=datasets,
+            output_repo_id=output_repo_id,
+            output_dir=output_dir,
+        )
+
+        total_episodes = sum(ds.num_episodes for ds in datasets)
+        _log_step(
+            f"Done! Merged {total_episodes} episodes into '{output_repo_id}'."
+        )
+
+        with _merge_lock:
+            _merge_state.update(
+                {
+                    "running": False,
+                    "success": True,
+                    "progress": "done",
+                }
+            )
+
+    except Exception as exc:
+        logger.error(f"Merge failed: {exc}", exc_info=True)
+        with _merge_lock:
+            _merge_state.update(
+                {
+                    "running": False,
+                    "success": False,
+                    "message": f"Error: {exc}",
+                    "progress": "error",
+                }
+            )

--- a/lelab/jobs.py
+++ b/lelab/jobs.py
@@ -43,7 +43,7 @@ from .train import TrainingRequest
 logger = logging.getLogger(__name__)
 
 
-JobState = Literal["running", "done", "failed", "interrupted"]
+JobState = Literal["running", "paused", "done", "failed", "interrupted"]
 
 
 class JobTarget(BaseModel):
@@ -921,16 +921,59 @@ class JobRegistry:
             if record is None:
                 raise JobNotFoundError(job_id)
             runner = self._runners.get(job_id)
-        if record.state != "running" or runner is None:
+        if record.state not in ("running", "paused") or runner is None:
             raise JobNotRunningError(job_id)
+        # If paused, resume first so the process can shut down cleanly
+        if record.state == "paused":
+            pid = runner.pid
+            if pid is not None and _pid_alive(pid):
+                os.kill(pid, signal.SIGCONT)
         runner.stop()
         # The watchdog will finalise the record (state, ended_at, exit_code).
         # Wait briefly so the caller sees the new state in the response.
         for _ in range(20):
             time.sleep(0.1)
             with self._lock:
-                if record.state != "running":
+                if record.state not in ("running", "paused"):
                     return record
+        return record
+
+    def pause(self, job_id: str) -> JobRecord:
+        """Send SIGSTOP to the training process — freezes it without killing."""
+        with self._lock:
+            record = self._records.get(job_id)
+            if record is None:
+                raise JobNotFoundError(job_id)
+            runner = self._runners.get(job_id)
+        if record.state != "running" or runner is None:
+            raise JobNotRunningError(job_id)
+        pid = runner.pid
+        if pid is None or not _pid_alive(pid):
+            raise JobNotRunningError(job_id)
+        os.kill(pid, signal.SIGSTOP)
+        with self._lock:
+            record.state = "paused"
+        self._persist_meta(job_id)
+        self._notify_change()
+        return record
+
+    def resume(self, job_id: str) -> JobRecord:
+        """Send SIGCONT to a paused training process."""
+        with self._lock:
+            record = self._records.get(job_id)
+            if record is None:
+                raise JobNotFoundError(job_id)
+            runner = self._runners.get(job_id)
+        if record.state != "paused":
+            raise ValueError(f"Job {job_id!r} is not paused (state: {record.state!r})")
+        pid = runner.pid if runner else record.process_pid
+        if pid is None or not _pid_alive(pid):
+            raise JobNotRunningError(job_id)
+        os.kill(pid, signal.SIGCONT)
+        with self._lock:
+            record.state = "running"
+        self._persist_meta(job_id)
+        self._notify_change()
         return record
 
     def drain_logs(self, job_id: str) -> builtins.list[LogLine]:

--- a/lelab/record.py
+++ b/lelab/record.py
@@ -50,8 +50,11 @@ recording_start_time = None  # Track when recording started
 session_end_elapsed_seconds = None  # Final session duration after the run ends
 current_episode = 1  # Track current episode number
 saved_episodes = 0  # Track how many episodes have been saved
-current_phase = "preparing"  # Track current phase: "preparing", "recording", "resetting", "completed"
+current_phase = "preparing"  # Track current phase: "preparing", "recording", "resetting", "completed", "paused"
 phase_start_time = None  # Track when current phase started
+recording_paused = False  # True while waiting for the user to resume between episodes
+_pause_resume_event = threading.Event()  # Set = NOT paused (running), clear = paused
+_pause_resume_event.set()
 last_recording_info: dict[str, Any] | None = (
     None  # Snapshot of the most recently completed dataset (for /dataset-info)
 )
@@ -190,6 +193,15 @@ def create_record_config(request: RecordingRequest) -> RecordConfig:
         private=request.private,
         streaming_encoding=request.streaming_encoding,
     )
+    # LeLab runs teleoperation/recording and video encoding on the same host.
+    # AV1 (libsvtav1) can saturate CPU and starve motor/camera I/O, causing
+    # dropped control-loop rate and serial read timeouts during recording.
+    # Favor a lightweight default encoder profile for interactive capture.
+    if dataset_config.video:
+        dataset_config.rgb_encoder.vcodec = "h264"
+        dataset_config.rgb_encoder.preset = "ultrafast"
+        dataset_config.encoder_threads = 1
+        logger.info("Using lightweight recording encoder profile: h264/ultrafast (threads=1)")
 
     # Create the main record config
     record_config = RecordConfig(
@@ -410,6 +422,35 @@ def handle_rerecord_episode() -> dict[str, Any]:
     }
 
 
+def handle_pause_recording() -> dict[str, Any]:
+    """Pause recording between episodes. Ends the current phase early and waits."""
+    global recording_paused, current_phase
+    if not recording_active or recording_events is None:
+        return {"success": False, "message": "No recording session is active"}
+    if recording_paused:
+        return {"success": False, "message": "Recording is already paused"}
+    recording_paused = True
+    _pause_resume_event.clear()
+    # End the active phase immediately so the worker reaches the pause checkpoint
+    recording_events["exit_early"] = True
+    recording_events["_exit_early_triggered"] = True
+    logger.info("Recording paused by user")
+    return {"success": True, "message": "Recording paused — current episode will be saved and recording will wait"}
+
+
+def handle_resume_recording() -> dict[str, Any]:
+    """Resume recording after a pause."""
+    global recording_paused, current_phase
+    if not recording_active:
+        return {"success": False, "message": "No recording session is active"}
+    if not recording_paused:
+        return {"success": False, "message": "Recording is not paused"}
+    recording_paused = False
+    _pause_resume_event.set()
+    logger.info("Recording resumed by user")
+    return {"success": True, "message": "Recording resumed"}
+
+
 def handle_recording_status() -> dict[str, Any]:
     """Handle recording status request"""
     # If recording is not active and phase is completed or error, indicate session has ended
@@ -428,13 +469,15 @@ def handle_recording_status() -> dict[str, Any]:
 
     status = {
         "recording_active": recording_active,
-        "current_phase": current_phase,  # "preparing", "recording", "resetting", "completed"
+        "recording_paused": recording_paused,
+        "current_phase": current_phase,  # "preparing", "recording", "resetting", "paused", "completed"
         "session_ended": session_ended,  # New field to indicate session completion
         "available_controls": {
             "stop_recording": recording_active,  # ESC key replacement
-            "exit_early": recording_active,  # Right arrow key replacement
-            "rerecord_episode": recording_active
-            and current_phase == "recording",  # Only during recording phase
+            "exit_early": recording_active and not recording_paused,  # Right arrow key replacement
+            "rerecord_episode": recording_active and current_phase == "recording",  # Only during recording phase
+            "pause_recording": recording_active and not recording_paused and current_phase in ("recording", "resetting"),
+            "resume_recording": recording_active and recording_paused,
         },
         "message": "Recording session failed with error - check logs"
         if current_phase == "error"
@@ -507,15 +550,8 @@ def camera_feed_frames(cam_key: str, fps: float = 15.0):
     while recording_active and current_robot is None and time.time() < deadline:
         time.sleep(0.1)
 
-    while recording_active:
-        # Snapshot the module global once per iteration. The recording teardown
-        # clears current_robot before it disconnects the cameras, so reading it
-        # a single time avoids dereferencing a robot that went away between the
-        # check and the access.
-        robot = current_robot
-        if robot is None:
-            break
-        cam = robot.cameras.get(cam_key)
+    while recording_active and current_robot is not None:
+        cam = current_robot.cameras.get(cam_key)
         if cam is None:
             # Unknown/removed camera — nothing to stream.
             break
@@ -673,7 +709,11 @@ def record_with_web_events(cfg: RecordConfig, web_events: dict) -> LeRobotDatase
     from lerobot.utils.feature_utils import hw_to_dataset_features
     from lerobot.utils.utils import log_say
 
-    global current_phase, phase_start_time, current_episode, saved_episodes, current_robot
+    global current_phase, phase_start_time, current_episode, saved_episodes, current_robot, recording_paused
+
+    # Reset pause state for new session
+    recording_paused = False
+    _pause_resume_event.set()
 
     robot = make_robot_from_config(cfg.robot)
     teleop = make_teleoperator_from_config(cfg.teleop) if cfg.teleop is not None else None
@@ -908,6 +948,20 @@ def record_with_web_events(cfg: RecordConfig, web_events: dict) -> LeRobotDatase
             # Check if we've completed all episodes
             if saved_episodes >= cfg.dataset.num_episodes:
                 break
+
+            # ── Pause checkpoint (between episodes) ───────────────────────
+            if recording_paused:
+                current_phase = "paused"
+                phase_start_time = None
+                print(f"⏸ STATUS CHANGE: Recording paused after episode {current_episode - 1}")
+                logger.info("Recording paused — waiting for resume")
+                _pause_resume_event.wait()  # blocks until handle_resume_recording sets it
+                # Restore flags that may have been set by the pause trigger
+                web_events["exit_early"] = False
+                web_events["_exit_early_triggered"] = False
+                print(f"▶ STATUS CHANGE: Recording resumed — continuing from episode {current_episode}")
+                logger.info("Recording resumed")
+            # ─────────────────────────────────────────────────────────────
 
             # Execute reset phase to prepare for next episode
             # Skip reset for the last episode that was just saved

--- a/lelab/server.py
+++ b/lelab/server.py
@@ -28,7 +28,8 @@ from typing import Any, Literal
 
 from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import JSONResponse
+from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from starlette.datastructures import Headers
@@ -36,8 +37,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import Response
 from starlette.types import Scope
 
-# Import our custom recording functionality
-from . import datasets as dataset_browser, record as _record
+from . import datasets as dataset_browser
 
 # Import our custom calibration functionality
 from .calibrate import CalibrationRequest, calibration_manager
@@ -48,18 +48,37 @@ from .jobs import (
     JobTarget,
     job_registry,
 )
+
+# Import our custom recording functionality
 from .record import (
     DatasetInfoRequest,
     RecordingRequest,
     UploadRequest,
+    camera_feed_frames,
     handle_delete_dataset,
     handle_exit_early,
     handle_get_dataset_info,
+    handle_pause_recording,
     handle_recording_status,
     handle_rerecord_episode,
+    handle_resume_recording,
     handle_start_recording,
     handle_stop_recording,
     handle_upload_dataset,
+    recording_active,
+)
+from .dataset_edit import (
+    DeleteEpisodesInplaceRequest,
+    DeleteEpisodesRequest,
+    MergeRequest,
+    handle_delete_episodes,
+    handle_delete_episodes_inplace,
+    handle_get_editable_datasets,
+    handle_get_episode_video_info,
+    handle_get_episodes,
+    handle_merge_status,
+    handle_serve_video_file,
+    handle_start_merge,
 )
 from .rollout import (
     InferenceRequest,
@@ -450,6 +469,7 @@ def camera_feed(cam_key: str):
     frontend just points an <img> at this URL. Only valid while a session is
     active; the generator ends itself when recording stops.
     """
+    import lelab.record as _record
     if not _record.recording_active:
         raise HTTPException(status_code=409, detail="No active recording session")
     return StreamingResponse(
@@ -470,6 +490,18 @@ def recording_rerecord_episode():
     return handle_rerecord_episode()
 
 
+@app.post("/pause-recording")
+def pause_recording():
+    """Pause recording after the current episode."""
+    return handle_pause_recording()
+
+
+@app.post("/resume-recording")
+def resume_recording():
+    """Resume recording from a paused state."""
+    return handle_resume_recording()
+
+
 @app.post("/upload-dataset")
 def upload_dataset(request: UploadRequest):
     """Upload dataset to HuggingFace Hub"""
@@ -487,6 +519,68 @@ def delete_dataset(request: DatasetInfoRequest):
     """Remove a recorded dataset directory from local disk."""
     return handle_delete_dataset(request)
 
+
+
+
+# ============================================================================
+# DATASET EDIT ENDPOINTS
+# ============================================================================
+
+@app.get("/edit/datasets")
+def edit_list_datasets():
+    """List local datasets enriched with episode counts for the Edit UI."""
+    return handle_get_editable_datasets()
+
+
+@app.post("/edit/merge")
+def edit_start_merge(request: MergeRequest):
+    """Start a background merge of multiple local datasets."""
+    return handle_start_merge(request)
+
+
+@app.get("/edit/merge-status")
+def edit_merge_status():
+    """Poll the progress of the currently running merge."""
+    return handle_merge_status()
+
+
+@app.post("/edit/delete-episodes")
+def edit_delete_episodes(request: DeleteEpisodesRequest):
+    """Delete episodes from a dataset and save result as a new dataset."""
+    return handle_delete_episodes(request)
+
+
+@app.post("/edit/delete-episodes-inplace")
+def edit_delete_episodes_inplace(request: DeleteEpisodesInplaceRequest):
+    """Delete episodes from a dataset in-place (replaces the source dataset)."""
+    return handle_delete_episodes_inplace(request)
+
+
+@app.get("/dataset-episodes")
+def dataset_episodes(repo_id: str):
+    """Return episode list (index, length, task) for a local dataset."""
+    return handle_get_episodes(repo_id)
+
+
+@app.get("/dataset-episode-video-info")
+def dataset_episode_video_info(repo_id: str, episode_index: int):
+    """Return video file paths and timestamps for one episode."""
+    return handle_get_episode_video_info(repo_id, episode_index)
+
+
+@app.get("/dataset-video-file")
+def dataset_video_file(repo_id: str, path: str):
+    """Stream a video file from a local dataset (supports HTTP Range requests)."""
+    from fastapi.responses import FileResponse as _FileResponse
+    try:
+        file_path = handle_serve_video_file(repo_id, path)
+    except (ValueError, FileNotFoundError) as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    return _FileResponse(
+        str(file_path),
+        media_type="video/mp4",
+        headers={"Accept-Ranges": "bytes"},
+    )
 
 # ============================================================================
 # JOB ENDPOINTS
@@ -667,6 +761,26 @@ def stop_job(job_id: str):
         raise HTTPException(status_code=404, detail=f"Job {job_id!r} not found") from exc
     except JobNotRunningError as exc:
         raise HTTPException(status_code=409, detail=f"Job {job_id!r} is not running") from exc
+
+
+@app.post("/jobs/{job_id}/pause")
+def pause_job(job_id: str):
+    try:
+        return job_registry.pause(job_id)
+    except JobNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=f"Job {job_id!r} not found") from exc
+    except (JobNotRunningError, ValueError) as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@app.post("/jobs/{job_id}/resume")
+def resume_job(job_id: str):
+    try:
+        return job_registry.resume(job_id)
+    except JobNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=f"Job {job_id!r} not found") from exc
+    except (JobNotRunningError, ValueError) as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @app.delete("/jobs/{job_id}", status_code=204)


### PR DESCRIPTION
## Summary

This PR improves LeLab recording and training workflows with the following features:

1. Add/Re-record specific demonstrations in existing datasets
2. Replay specific episodes from dataset videos
3. Pause/Resume recording from the UI
4. Pause/Resume local training jobs from the UI
5. Fix episode listing bug ("No episodes found") for HF dataset metadata

## Main changes

### Dataset editing (specific demonstrations)

- Added dataset episode listing endpoint: `GET /dataset-episodes`
- Added in-place episode deletion flow before re-recording selected episodes
- Added a dedicated frontend page for the Add/Re-record workflow:
  - Dataset selection
  - Episode selection
  - Delete selected episodes
  - Start recording to append/recreate demonstrations

**UI screenshots**

- Main dataset edit entry point  
  <img width="914" height="427" alt="Main frontend edit" src="https://github.com/user-attachments/assets/3d1076ac-530d-413d-ae55-f3944a5f2218" />

- Dataset editing views  
  <img width="1177" height="566" alt="Dataset edition window 1" src="https://github.com/user-attachments/assets/b87eee12-ae5c-48cf-80aa-2b0d8ad7d216" />
  <img width="637" height="581" alt="Dataset edition window 2" src="https://github.com/user-attachments/assets/24377460-6e0d-48de-8408-fa4d1b2edb2c" />

### Episode replay

- Added endpoint to fetch per-episode video segment metadata:
  - `file_path`
  - `from_timestamp`
  - `to_timestamp`
- Added secure video file serving endpoint for replay
- Added replay modal in frontend with per-camera video playback for selected episodes

**UI screenshots**

- Episode re-recording  
  <img width="1055" height="1042" alt="Episode rerecording" src="https://github.com/user-attachments/assets/d331d8c9-98cf-438c-bf4d-f59514219c23" />

- Episode replay  
  <img width="903" height="437" alt="Episode replay" src="https://github.com/user-attachments/assets/43d6778b-bd0a-437f-b364-8ae107ad0dd2" />

### Pause/Resume recording

- Added recording pause state and pause/resume handlers
- Added endpoints:
  - `POST /pause-recording`
  - `POST /resume-recording`
- Added frontend Pause/Resume controls and paused-state handling

### Pause/Resume training (local jobs)

- Added `paused` job state
- Added pause/resume operations for local jobs using `SIGSTOP` / `SIGCONT`
- Added endpoints:
  - `POST /jobs/{job_id}/pause`
  - `POST /jobs/{job_id}/resume`
- Added frontend Pause/Resume controls and state-aware polling for training jobs

**UI screenshot**

<img width="1301" height="858" alt="Training pause resume" src="https://github.com/user-attachments/assets/fb7bc601-dfdf-4739-8ff6-6b7937756b69" />

## Files changed

- `lelab/record.py`
- `lelab/server.py`
- `lelab/dataset_edit.py`
- `lelab/jobs.py`
- `frontend/src/pages/Recording.tsx`
- `frontend/src/pages/RerecordEpisode.tsx` (new)
- `frontend/src/pages/Landing.tsx`
- `frontend/src/App.tsx`
- `frontend/src/pages/Training.tsx`
- `frontend/src/lib/jobsApi.ts`

## Notes

- Training pause/resume currently applies to the local runner.
- This PR is focused on LeLab UX and dataset edition workflow.