### PR TITLE
fix(server): initialize COM for Windows camera discovery

### DIFF
--- a/lelab/server.py
+++ b/lelab/server.py
@@ -1008,6 +1008,28 @@ def _generic_cv2_cameras(backend) -> list[dict[str, Any]]:
     return cameras
 
 
+@contextlib.contextmanager
+def _windows_com_initialized():
+    """Initialize COM for the current Windows worker thread when available."""
+    try:
+        import comtypes
+    except ImportError:
+        yield
+        return
+
+    try:
+        comtypes.CoInitialize()
+    except OSError as e:
+        logger.warning("Windows COM initialization failed: %s", e)
+        yield
+        return
+
+    try:
+        yield
+    finally:
+        comtypes.CoUninitialize()
+
+
 def _windows_cameras() -> list[dict[str, Any]]:
     """Enumerate Windows cameras with their real DirectShow names.
 
@@ -1017,16 +1039,17 @@ def _windows_cameras() -> list[dict[str, Any]]:
     frontend match each index to the browser's ``MediaDeviceInfo.label`` for the
     live preview. Falls back to generic names if pygrabber is unavailable.
     """
-    try:
-        from pygrabber.dshow_graph import FilterGraph
+    with _windows_com_initialized():
+        try:
+            from pygrabber.dshow_graph import FilterGraph
 
-        names = FilterGraph().get_input_devices()
-    except Exception as e:  # ImportError, or a COM/DirectShow failure
-        logger.warning("pygrabber unavailable; using generic camera names: %s", e)
-        import cv2
+            names = FilterGraph().get_input_devices()
+        except Exception as e:  # ImportError, or a COM/DirectShow failure
+            logger.warning("pygrabber unavailable; using generic camera names: %s", e)
+            import cv2
 
-        return _generic_cv2_cameras(cv2.CAP_DSHOW)
-    return [{"index": i, "name": name, "available": True} for i, name in enumerate(names)]
+            return _generic_cv2_cameras(cv2.CAP_DSHOW)
+        return [{"index": i, "name": name, "available": True} for i, name in enumerate(names)]
 
 
 def _v4l2_camera_name(index: int) -> str | None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -160,6 +160,44 @@ def _install_fake_pygrabber(monkeypatch: pytest.MonkeyPatch, filter_graph_cls) -
     monkeypatch.setitem(sys.modules, "pygrabber.dshow_graph", module)
 
 
+def _install_fake_comtypes(
+    monkeypatch: pytest.MonkeyPatch,
+    co_initialize,
+    co_uninitialize,
+) -> None:
+    import sys
+    import types
+
+    module = types.ModuleType("comtypes")
+    module.CoInitialize = co_initialize
+    module.CoUninitialize = co_uninitialize
+    monkeypatch.setitem(sys.modules, "comtypes", module)
+
+
+def test_windows_cameras_initializes_com_in_worker_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DirectShow is called only while COM is initialized for this thread."""
+    from lelab import server
+
+    events = []
+
+    class _FakeGraph:
+        def get_input_devices(self) -> list[str]:
+            events.append("enumerate")
+            return ["USB webcam"]
+
+    _install_fake_comtypes(
+        monkeypatch,
+        lambda: events.append("initialize"),
+        lambda: events.append("uninitialize"),
+    )
+    _install_fake_pygrabber(monkeypatch, _FakeGraph)
+
+    assert server._windows_cameras() == [
+        {"index": 0, "name": "USB webcam", "available": True},
+    ]
+    assert events == ["initialize", "enumerate", "uninitialize"]
+
+
 def test_windows_cameras_uses_real_directshow_names(monkeypatch: pytest.MonkeyPatch) -> None:
     """The Windows path returns pygrabber's real device names in index order so
     the frontend can match each camera to its browser deviceId (issues #12/#16).


### PR DESCRIPTION
## Context

I use LeLab to test and iterate on my robot configurations. While setting it up on Windows, I ran into this issue when trying to use the camera configuration flow in the web interface.

The problem was reproducible with two USB webcams and occurred during camera discovery, before recording started. After initializing COM in the worker thread, the cameras were detected normally and their DirectShow names were returned correctly.

I hope this makes the Windows setup experience a little smoother for other LeLab users as well.

## Background

On Windows, LeLab’s `/available-cameras` endpoint runs `_windows_cameras()` as a synchronous FastAPI route. Starlette executes synchronous routes in a worker thread.

The Windows implementation uses `pygrabber` to enumerate DirectShow devices and return their real friendly names. These names are required by the frontend to match the server-side camera index with the browser’s `MediaDeviceInfo.deviceId`.

## Root cause

COM initialization is apartment/thread-local on Windows. Initializing COM in the main Python thread does not initialize it in a FastAPI worker thread.

`pygrabber` calls DirectShow from that worker thread without first initializing COM, which raises:

`WinError -2147221008: CoInitialize has not been called`

LeLab then falls back to probing camera indices with OpenCV using the DirectShow backend (`CAP_DSHOW`). That fallback runs in the same uninitialized thread, so OpenCV also fails with warnings such as:

`VIDEOIO(DSHOW): backend is generally available but can't be used to capture by index`

This caused LeLab to lose the real camera names and prevented reliable camera discovery from the web UI.

## Fix

Initialize COM for the current worker thread before calling `pygrabber` or probing DirectShow cameras, and always call `CoUninitialize()` when the operation finishes.

The initialization is kept in a small context manager so that:

- COM is initialized in the thread that actually uses DirectShow;
- cleanup is guaranteed through `finally`;
- the existing graceful fallback remains available if `comtypes` is not installed or COM initialization fails.
